### PR TITLE
expose revision information for questions in the API.

### DIFF
--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -220,6 +220,7 @@ class api extends external_api {
                         'text' => external_format_text($question->questiontext, $question->questiontextformat, $context->id)[0],
                         'defaultmarks' => $question->defaultmark,
                         'type' => $question->qtype,
+                        'questionbankentryid' => $question->questionbankentryid,
                         'quizzes' => [ $quiz->id ],
                     ];
                     // bolt on the question ids of all revisions of this question
@@ -266,6 +267,7 @@ class api extends external_api {
                 'revisions' => new external_multiple_structure(
                     new external_value(PARAM_INT, 'Question ID', VALUE_REQUIRED),
                 ),
+                'questionbankentryid' =>  new external_value(PARAM_INT, 'The question bank entry id for this question', VALUE_REQUIRED),
             ]),
         );
     }

--- a/version.php
+++ b/version.php
@@ -6,6 +6,6 @@
  */
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2023091500;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2023091800;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2022111800;        // Requires this Moodle version
 $plugin->component = 'tool_ucsfsomapi';      // Full name of the plugin (used for diagnostics)


### PR DESCRIPTION
this adds a revisions data-point to the payload for questions queried from the get_questions endpoint.
the revisions array includes the question ids of all revisions of a given question, including the question itself.