### PR TITLE
Add set_question_attempt_mark API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -18,4 +18,159 @@ in the UCSF School of Medicine (SOM).
 * rename directory `tool_ucsfsomapi` to `ucsfsomapi`
 * navigate on your moodle page to admin --> notifications and follow the instructions
 
-Copyright (c) 2021 The Regents of the University of California.
+# API Endpoints
+
+API entry point: https://{your.moodle.site}/webservice/rest/server.php
+
+<details>
+<summary><h2>Get courses for given course-categories</h2></summary>
+
+**Expected input:**
+
+- `ws-token` ... your API token
+- `categoryids` ... one or more course category ids
+- `ws-function` ... `tool_ucsfsomapi_get_courses`
+- `moodlewsrestformat` ... `json` or `xml`
+
+**Example:**
+
+`curl -F "wstoken=XXXXXXXXXXXXXXXXXXXXXXXXXX" -F "wsfunction=tool_ucsfsomapi_get_courses" -F "moodlewsrestformat=json" -F "categoryids[]=309" -F "categoryids[]=310"  -X POST https://{your.moodle.site}/webservice/rest/server.php`
+
+</details>
+
+<details>
+<summary><h2>Get quizzes for given courses</h2></summary>
+
+**Expected input:**
+
+- `ws-token` ... your API token
+- `courseids` ... one or more course ids
+- `ws-function` ... `tool_ucsfsomapi_get_quizzes`
+- `moodlewsrestformat` ... `json` or `xml`
+
+**Example:**
+
+`curl -F "wstoken=XXXXXXXXXXXXXXXXXXXXXXXXXX" -F "wsfunction=tool_ucsfsomapi_get_quizzes" -F "moodlewsrestformat=json" -F "courseids[]=1014" -X POST https://{your.moodle.site}/webservice/rest/server.php`
+
+</details>
+
+<details>
+<summary><h2>Get questions for given quizzes</h2></summary>
+
+**Expected input:**
+
+- `ws-token` ... your API token
+- `quizids` ... one or more quiz ids
+- `ws-function` ... `tool_ucsfsomapi_get_questions`
+- `moodlewsrestformat` ... `json` or `xml`
+
+**Example:**
+
+`curl -F "wstoken=XXXXXXXXXXXXXXXXXXXXXXXXXX" -F "wsfunction=tool_ucsfsomapi_get_questions" -F "moodlewsrestformat=json" -F "quizids[]=18363" -F "quizids[]=19139" -X POST https://{your.moodle.site}/webservice/rest/server.php`
+
+</details>
+
+<details>
+<summary><h2>Get quiz attempts for given quizzes</h2></summary>
+
+**Expected input:**
+
+- `ws-token` ... your API token
+- `quizids` ... one or more quiz ids
+- `ws-function` ... `tool_ucsfsomapi_get_attempts`
+- `moodlewsrestformat` ... `json` or `xml`
+
+**Example:**
+
+`curl -F "wstoken=XXXXXXXXXXXXXXXXXXXXXXXXXX" -F "wsfunction=tool_ucsfsomapi_get_attempts" -F "moodlewsrestformat=json" -F "quizids[]=18363" -F "quizids[]=19139" -X POST https://{your.moodle.site}/webservice/rest/server.php`
+
+</details>
+
+<details>
+<summary><h2>Get users by ids</h2></summary>
+
+**Expected input:**
+
+- `ws-token` ... your API token
+- `userids` ... one or more user ids
+- `ws-function` ... `tool_ucsfsomapi_get_users`
+- `moodlewsrestformat` ... `json` or `xml`
+
+**Example:**
+
+`curl -F "wstoken=XXXXXXXXXXXXXXXXXXXXXXXXXX" -F "wsfunction=tool_ucsfsomapi_get_users" -F "moodlewsrestformat=json" -F "userids[]=34345" -F "userids[]=32728" -X POST https://{your.moodle.site}/webservice/rest/server.php`
+
+</details>
+
+<details>
+<summary><h2>Mark a question attempt by its id</h2></summary>
+
+**Expected input:**
+
+- `ws-token` ... your API token
+- `ws-function` ... `tool_ucsfsomapi_set_question_attempt_mark`
+- `moodlewsrestformat` ... `json` or `xml`
+- `attemptid` (Required) ... The question attempt id to set mark (int)
+- `mark` (Required) ... Mark for this question attempt (string)
+- `comment` (Optional, defaults to "null") ... Grader's comment (string)
+
+**Example:**
+
+```bash
+curl -F "wstoken=XXXXXXXXXXXXXXXXXXXXXXXXXX" \
+     -F "wsfunction=tool_ucsfsomapi_set_question_attempt_mark" \
+     -F "moodlewsrestformat=json" \
+     -F "attemptid=12345" \
+     -F "mark=1.0" \
+     -F "comment=Good work" \
+     -X POST https://{your.moodle.site}/webservice/rest/server.php
+```
+
+**Response:**
+
+An `int` value like `0 => OK`, `1 => FAILED` as defined in [lib/grade/constants.php](https://github.com/ucsf-education/moodle/blob/UCSFCLE_404_STABLE/lib/grade/constants.php#L98)
+
+```
+/**
+ * GRADE_UPDATE_OK - Grade updated completed successfully.
+ */
+define('GRADE_UPDATE_OK', 0);
+
+/**
+ * GRADE_UPDATE_FAILED - Grade updated failed.
+ */
+define('GRADE_UPDATE_FAILED', 1);
+```
+
+**Error exception examples:**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<EXCEPTION class="invalid_parameter_exception">
+    <MESSAGE>Invalid parameter value detected</MESSAGE>
+    <DEBUGINFO></DEBUGINFO>
+</EXCEPTION>
+
+<?xml version="1.0" encoding="UTF-8"?>
+<EXCEPTION class="moodle_exception">
+    <MESSAGE>No such attempt ID exists</MESSAGE>
+    <DEBUGINFO></DEBUGINFO>
+</EXCEPTION>
+
+<?xml version="1.0" encoding="UTF-8"?>
+<EXCEPTION class="moodle_exception">
+    <MESSAGE>Attempt has not closed yet</MESSAGE>
+    <DEBUGINFO></DEBUGINFO>
+</EXCEPTION>
+
+<?xml version="1.0" encoding="UTF-8"?>
+<EXCEPTION class="moodle_exception">
+    <MESSAGE>Sorry, but you do not currently have permissions to do that (Grade quizzes manually).</MESSAGE>
+    <DEBUGINFO></DEBUGINFO>
+</EXCEPTION>
+```
+
+</details>
+
+
+Copyright (c) 2025 The Regents of the University of California.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ API entry point: https://{your.moodle.site}/webservice/rest/server.php
 
 **Expected input:**
 
-- `ws-token` ... your API token
+- `wstoken` ... your API token
 - `categoryids` ... one or more course category ids
-- `ws-function` ... `tool_ucsfsomapi_get_courses`
+- `wsfunction` ... `tool_ucsfsomapi_get_courses`
 - `moodlewsrestformat` ... `json` or `xml`
 
 **Example:**
@@ -43,9 +43,9 @@ API entry point: https://{your.moodle.site}/webservice/rest/server.php
 
 **Expected input:**
 
-- `ws-token` ... your API token
+- `wstoken` ... your API token
 - `courseids` ... one or more course ids
-- `ws-function` ... `tool_ucsfsomapi_get_quizzes`
+- `wsfunction` ... `tool_ucsfsomapi_get_quizzes`
 - `moodlewsrestformat` ... `json` or `xml`
 
 **Example:**
@@ -59,9 +59,9 @@ API entry point: https://{your.moodle.site}/webservice/rest/server.php
 
 **Expected input:**
 
-- `ws-token` ... your API token
+- `wstoken` ... your API token
 - `quizids` ... one or more quiz ids
-- `ws-function` ... `tool_ucsfsomapi_get_questions`
+- `wsfunction` ... `tool_ucsfsomapi_get_questions`
 - `moodlewsrestformat` ... `json` or `xml`
 
 **Example:**
@@ -75,9 +75,9 @@ API entry point: https://{your.moodle.site}/webservice/rest/server.php
 
 **Expected input:**
 
-- `ws-token` ... your API token
+- `wstoken` ... your API token
 - `quizids` ... one or more quiz ids
-- `ws-function` ... `tool_ucsfsomapi_get_attempts`
+- `wsfunction` ... `tool_ucsfsomapi_get_attempts`
 - `moodlewsrestformat` ... `json` or `xml`
 
 **Example:**
@@ -91,9 +91,9 @@ API entry point: https://{your.moodle.site}/webservice/rest/server.php
 
 **Expected input:**
 
-- `ws-token` ... your API token
+- `wstoken` ... your API token
 - `userids` ... one or more user ids
-- `ws-function` ... `tool_ucsfsomapi_get_users`
+- `wsfunction` ... `tool_ucsfsomapi_get_users`
 - `moodlewsrestformat` ... `json` or `xml`
 
 **Example:**
@@ -107,8 +107,8 @@ API entry point: https://{your.moodle.site}/webservice/rest/server.php
 
 **Expected input:**
 
-- `ws-token` ... your API token
-- `ws-function` ... `tool_ucsfsomapi_set_question_attempt_mark`
+- `wstoken` ... your API token
+- `wsfunction` ... `tool_ucsfsomapi_set_question_attempt_mark`
 - `moodlewsrestformat` ... `json` or `xml`
 - `attemptid` (Required) ... The question attempt id to set mark (int)
 - `mark` (Required) ... Mark for this question attempt (string)

--- a/classes/event/question_attempt_marked.php
+++ b/classes/event/question_attempt_marked.php
@@ -64,8 +64,18 @@ class question_attempt_marked extends \core\event\base {
      * @return string
      */
     public function get_description() {
-        return "The user with id '$this->userid' marked the question attempt with id '$this->objectid' for the quiz " .
-            "attempt with id '{$this->other['attemptid']}' with course module id '$this->contextinstanceid'.";
+        return "The user with id '$this->userid' marked the question attempt with id '{$this->other['attemptid']}' for the quiz " .
+            "attempt with id '{$this->objectid}' in course module id '{$this->contextinstanceid}'.";
+    }
+
+    /**
+     * Returns relevant URL.
+     *
+     * @return \moodle_url
+     */
+    public function get_url() {
+        return new \moodle_url('/mod/quiz/comment.php', ['attempt' => $this->other['attemptid'],
+            'slot' => $this->other['slot']]);
     }
 
     /**
@@ -95,7 +105,7 @@ class question_attempt_marked extends \core\event\base {
      * @return array{db: string, restore: string}
      */
     public static function get_objectid_mapping() {
-        return ['db' => 'question', 'restore' => 'question'];
+        return ['db' => 'question_attempts', 'restore' => 'question_attempts'];
     }
 
     /**

--- a/classes/event/question_attempt_marked.php
+++ b/classes/event/question_attempt_marked.php
@@ -1,0 +1,106 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The tool_ucsfsomapi question_attempt_marked event.
+ *
+ * @package    tool_ucsfsomapi
+ * @copyright  The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace tool_ucsfsomapi\event;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * The tool_ucsfsomapi question_attempt_marked event class.
+ *
+ * @property-read array $other {
+ *      Extra information about event.
+ *
+ *      - int quizid: the id of the quiz.
+ *      - int attemptid: the id of the attempt.
+ *      - int slot: the question number in the attempt.
+ * }
+ *
+ * @package    tool_ucsfsomapi
+ * @copyright  The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class question_attempt_marked extends \core\event\base {
+
+    /**
+     * Init method.
+     */
+    protected function init() {
+        $this->data['objecttable'] = 'question';
+        $this->data['crud'] = 'u';
+        $this->data['edulevel'] = self::LEVEL_TEACHING;
+    }
+
+    /**
+     * Returns localised general event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('eventquestionattemptmarked', 'tool_ucsfsomapi');
+    }
+
+    /**
+     * Returns description of what happened.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "The user with id '$this->userid' marked the question attempt with id '$this->objectid' for the attempt " .
+            "with id '{$this->other['attemptid']}' for the quiz with course module id '$this->contextinstanceid'.";
+    }
+
+    /**
+     * Custom validation.
+     *
+     * @throws \coding_exception
+     * @return void
+     */
+    protected function validate_data() {
+        parent::validate_data();
+
+        if (!isset($this->other['quizid'])) {
+            throw new \coding_exception('The \'quizid\' value must be set in other.');
+        }
+
+        if (!isset($this->other['attemptid'])) {
+            throw new \coding_exception('The \'attemptid\' value must be set in other.');
+        }
+
+        if (!isset($this->other['slot'])) {
+            throw new \coding_exception('The \'slot\' value must be set in other.');
+        }
+    }
+
+    public static function get_objectid_mapping() {
+        return ['db' => 'question', 'restore' => 'question'];
+    }
+
+    public static function get_other_mapping() {
+        $othermapped = [];
+        $othermapped['quizid'] = ['db' => 'quiz', 'restore' => 'quiz'];
+        $othermapped['attemptid'] = ['db' => 'quiz_attempts', 'restore' => 'quiz_attempt'];
+
+        return $othermapped;
+    }
+}

--- a/classes/event/question_attempt_marked.php
+++ b/classes/event/question_attempt_marked.php
@@ -23,8 +23,6 @@
  */
 namespace tool_ucsfsomapi\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The tool_ucsfsomapi question_attempt_marked event class.
  *
@@ -66,8 +64,8 @@ class question_attempt_marked extends \core\event\base {
      * @return string
      */
     public function get_description() {
-        return "The user with id '$this->userid' marked the question attempt with id '$this->objectid' for the attempt " .
-            "with id '{$this->other['attemptid']}' for the quiz with course module id '$this->contextinstanceid'.";
+        return "The user with id '$this->userid' marked the question attempt with id '$this->objectid' for the quiz " .
+            "attempt with id '{$this->other['attemptid']}' with course module id '$this->contextinstanceid'.";
     }
 
     /**
@@ -92,10 +90,18 @@ class question_attempt_marked extends \core\event\base {
         }
     }
 
+    /**
+     * Summary of get_objectid_mapping
+     * @return array{db: string, restore: string}
+     */
     public static function get_objectid_mapping() {
         return ['db' => 'question', 'restore' => 'question'];
     }
 
+    /**
+     * Summary of get_other_mapping
+     * @return array{quizid: array{db: string, restore: string}, attemptid: array{db: string, restore: string}}
+     */
     public static function get_other_mapping() {
         $othermapped = [];
         $othermapped['quizid'] = ['db' => 'quiz', 'restore' => 'quiz'];

--- a/classes/event/set_question_attempt_mark_called.php
+++ b/classes/event/set_question_attempt_mark_called.php
@@ -65,8 +65,27 @@ class set_question_attempt_mark_called extends \core\event\base {
      * @return string
      */
     public function get_description() {
-        return "The user with id '$this->userid' called set_question_attempt_mark for the question attempt id " .
-            "'$this->objectid' to set mark to '{$this->other['mark']}' with grader's comment '{$this->other['comment']}'.";
+        global $CFG;
+
+        $description = "The user with id '$this->userid' called set_question_attempt_mark for the question attempt id " .
+                       "'$this->objectid' to set mark to '{$this->other['mark']}'";
+
+        if (!empty($this->other['comment'])) {
+            $description .= " with grader's comment '{$this->other['comment']}'";
+        } else {
+            $description .= " without a comment.";
+        }
+
+        // Only display when debugging is enabled to DEBGUG_DEVELOPER level on the site.
+        if ($CFG->debug > DEBUG_DEVELOPER) {
+            if (!empty($this->other['GET'])) {
+                $description .= "\nGet data: {$this->other['GET']}";
+            }
+            if (!empty($this->other['POST'])) {
+                $description .= "\nPost data: {$this->other['POST']}";
+            }
+        }
+        return $description;
     }
 
     /**
@@ -88,6 +107,6 @@ class set_question_attempt_mark_called extends \core\event\base {
      * @return array{db: string, restore: string}
      */
     public static function get_objectid_mapping() {
-        return ['db' => 'question', 'restore' => 'question'];
+        return ['db' => 'question_attempts', 'restore' => 'question_attempts'];
     }
 }

--- a/classes/event/set_question_attempt_mark_called.php
+++ b/classes/event/set_question_attempt_mark_called.php
@@ -56,7 +56,7 @@ class set_question_attempt_mark_called extends \core\event\base {
      * @return string
      */
     public static function get_name() {
-        return get_string('eventset_question_attempt_mark_called', 'tool_ucsfsomapi');
+        return get_string('eventsetquestionattemptmarkcalled', 'tool_ucsfsomapi');
     }
 
     /**
@@ -80,10 +80,6 @@ class set_question_attempt_mark_called extends \core\event\base {
 
         if (!isset($this->other['mark'])) {
             throw new \coding_exception('The \'mark\' value must be set in other.');
-        }
-
-        if (!isset($this->other['comment'])) {
-            throw new \coding_exception('The \'comment\' value must be set in other.');
         }
     }
 

--- a/classes/event/set_question_attempt_mark_called.php
+++ b/classes/event/set_question_attempt_mark_called.php
@@ -77,7 +77,7 @@ class set_question_attempt_mark_called extends \core\event\base {
         }
 
         // Only display when debugging is enabled to DEBGUG_DEVELOPER level on the site.
-        if ($CFG->debug > DEBUG_DEVELOPER) {
+        if ($CFG->debug === DEBUG_DEVELOPER) {
             if (!empty($this->other['GET'])) {
                 $description .= "\nGet data: {$this->other['GET']}";
             }

--- a/classes/event/set_question_attempt_mark_called.php
+++ b/classes/event/set_question_attempt_mark_called.php
@@ -1,0 +1,99 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The tool_ucsfsomapi set_question_attempt_mark_called event.
+ *
+ * @package    tool_ucsfsomapi
+ * @copyright  The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace tool_ucsfsomapi\event;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * The tool_ucsfsomapi set_question_attempt_mark_called event class.
+ *
+ * @property-read array $other {
+ *      Extra information about event.
+ *
+ *      - int quizid: the id of the quiz.
+ *      - int attemptid: the id of the attempt.
+ *      - int slot: the question number in the attempt.
+ * }
+ *
+ * @package    tool_ucsfsomapi
+ * @copyright  The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class set_question_attempt_mark_called extends \core\event\base {
+
+    /**
+     * Init method.
+     */
+    protected function init() {
+        $this->data['objecttable'] = 'question';
+        $this->data['crud'] = 'u';
+        $this->data['edulevel'] = self::LEVEL_TEACHING;
+        $this->context = \context_system::instance();
+    }
+
+    /**
+     * Returns localised general event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('eventset_question_attempt_mark_called', 'tool_ucsfsomapi');
+    }
+
+    /**
+     * Returns description of what happened.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "The user with id '$this->userid' called set_question_attempt_mark for the question attempt id '$this->objectid' to" .
+            "set mark to '{$this->other['mark']}' with grader's comment '{$this->other['comment']}'.";
+    }
+
+   /**
+     * Custom validation.
+     *
+     * @throws \coding_exception
+     * @return void
+     */
+    protected function validate_data() {
+        parent::validate_data();
+
+        if (!isset($this->other['mark'])) {
+            throw new \coding_exception('The \'mark\' value must be set in other.');
+        }
+
+        if (!isset($this->other['comment'])) {
+            throw new \coding_exception('The \'comment\' value must be set in other.');
+        }
+    }
+
+    public static function get_objectid_mapping() {
+        return ['db' => 'question', 'restore' => 'question'];
+    }
+
+    public static function get_other_mapping() {
+        return false;
+    }
+}

--- a/classes/event/set_question_attempt_mark_called.php
+++ b/classes/event/set_question_attempt_mark_called.php
@@ -23,8 +23,6 @@
  */
 namespace tool_ucsfsomapi\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The tool_ucsfsomapi set_question_attempt_mark_called event class.
  *
@@ -67,11 +65,11 @@ class set_question_attempt_mark_called extends \core\event\base {
      * @return string
      */
     public function get_description() {
-        return "The user with id '$this->userid' called set_question_attempt_mark for the question attempt id '$this->objectid' to" .
-            "set mark to '{$this->other['mark']}' with grader's comment '{$this->other['comment']}'.";
+        return "The user with id '$this->userid' called set_question_attempt_mark for the question attempt id " .
+            "'$this->objectid' to set mark to '{$this->other['mark']}' with grader's comment '{$this->other['comment']}'.";
     }
 
-   /**
+    /**
      * Custom validation.
      *
      * @throws \coding_exception
@@ -89,11 +87,11 @@ class set_question_attempt_mark_called extends \core\event\base {
         }
     }
 
+    /**
+     * Summary of get_objectid_mapping
+     * @return array{db: string, restore: string}
+     */
     public static function get_objectid_mapping() {
         return ['db' => 'question', 'restore' => 'question'];
-    }
-
-    public static function get_other_mapping() {
-        return false;
     }
 }

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -740,7 +740,7 @@ class api extends external_api {
 
         // If $qadata is empty return error or exception.
         if (empty($qadata)) {
-            throw new moodle_exception('invalidquestionid', 'quiz');
+            throw new moodle_exception('invalidattemptid', 'quiz_grading');
         }
 
         $quizattemptid = $qadata->qaid;

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -727,7 +727,7 @@ class api extends external_api {
 
         // If $qadata is empty return error or exception.
         if (empty($qadata)) {
-            throw new \moodle_exception('invalidquestionid', 'quiz');
+            throw new moodle_exception('invalidquestionid', 'quiz');
         }
 
         $quizattemptid = $qadata->qaid;
@@ -738,7 +738,7 @@ class api extends external_api {
 
         // Can only grade finished attempts.
         if (!$quizattemptobj->is_finished()) {
-            throw new \moodle_exception('attemptclosed', 'quiz');
+            throw new moodle_exception('attemptclosed', 'quiz');
         }
 
         // Check login and permissions.
@@ -752,10 +752,10 @@ class api extends external_api {
         // Set the sequence check count to the latest value.
         $_POST[$prefix.":sequencecheck"] = $qa->get_sequence_check_count();
 
-        $_POST["attempt"] = "$quizattemptid";
+        $_POST["attempt"] = (string) $quizattemptid;
         $_POST["slot"] = (string) $slot;
         $_POST["slots"] = (string) $slot;      // This is set to $slot in /mod/quiz/comment.php, line 122 (is this a bug?).
-        $_POST[$prefix."-mark"] = "$mark";
+        $_POST[$prefix."-mark"] = (string) $mark;
         $_POST[$prefix."-maxmark"] = $qa->get_max_mark();
         $_POST[$prefix.":minfraction"] = $qa->get_min_fraction();
         $_POST[$prefix.":maxfraction"] = $qa->get_max_fraction();

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -704,6 +704,17 @@ class api extends external_api {
         require_once($CFG->dirroot . '/lib/grade/constants.php');
         require_once($CFG->dirroot . '/mod/quiz/locallib.php');
 
+        // Log this API call.
+        $params = [
+            'objectid' => $questionattemptid,
+            'other' => [
+                'mark' => $mark,
+                'comment' => $comment,
+            ],
+        ];
+        $event = \tool_ucsfsomapi\event\set_question_attempt_mark_called::create($params);
+        $event->trigger();
+
         $params = [
             'attemptid' => $questionattemptid,
             'mark' => $mark,
@@ -793,7 +804,7 @@ class api extends external_api {
                     'slot' => $slot,
                 ],
             ];
-            $event = \mod_quiz\event\question_manually_graded::create($params);
+            $event = \tool_ucsfsomapi\event\question_attempt_marked::create($params);
             $event->trigger();
 
             return GRADE_UPDATE_OK;

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -710,6 +710,8 @@ class api extends external_api {
             'other' => [
                 'mark' => $mark,
                 'comment' => $comment,
+                'GET' => json_encode($_GET, true),
+                'POST' => json_encode($_POST, true),
             ],
         ];
         $event = \tool_ucsfsomapi\event\set_question_attempt_mark_called::create($params);

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -778,7 +778,6 @@ class api extends external_api {
                 list($draftitemid, $commenttext) = $commentstep->prepare_response_files_draft_itemid_with_text(
                 'bf_comment', $quizattemptobj->get_quizobj()->get_context()->id, $commenttext);
         } else {
-            $commenttext = '';
             $draftitemid = file_get_unused_draft_itemid();
         }
         $_POST[$prefix."-comment"] = $comment ?? $commenttext;

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -705,13 +705,30 @@ class api extends external_api {
         require_once($CFG->dirroot . '/mod/quiz/locallib.php');
 
         // Log this API call.
+        $getdata = $_GET;
+        $postdata = $_POST;
+
+        // Mask the wstoken in the post data for security reasons.
+        if (isset($getdata['wstoken'])) {
+            $wstoken = $getdata['wstoken'];
+            $getdata['wstoken'] = substr($wstoken, 0, 1)
+                                    . str_repeat('*', 5)
+                                    . substr($wstoken, -4);
+        }
+        if (isset($postdata['wstoken'])) {
+            $wstoken = $postdata['wstoken'];
+            $postdata['wstoken'] = substr($wstoken, 0, 1)
+                                    . str_repeat('*', 5)
+                                    . substr($wstoken, -4);
+        }
+
         $params = [
             'objectid' => $questionattemptid,
             'other' => [
                 'mark' => $mark,
                 'comment' => $comment,
-                'GET' => json_encode($_GET, true),
-                'POST' => json_encode($_POST, true),
+                'GET' => json_encode($getdata, true),
+                'POST' => json_encode($postdata, true),
             ],
         ];
         $event = \tool_ucsfsomapi\event\set_question_attempt_mark_called::create($params);

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -753,8 +753,8 @@ class api extends external_api {
         $_POST[$prefix.":sequencecheck"] = $qa->get_sequence_check_count();
 
         $_POST["attempt"] = "$quizattemptid";
-        $_POST["slot"] = "$slot";
-        $_POST["slots"] = "$slot";      // This is set to $slot in /mod/quiz/comment.php, line 122 (is this a bug?).
+        $_POST["slot"] = (string) $slot;
+        $_POST["slots"] = (string) $slot;      // This is set to $slot in /mod/quiz/comment.php, line 122 (is this a bug?).
         $_POST[$prefix."-mark"] = "$mark";
         $_POST[$prefix."-maxmark"] = $qa->get_max_mark();
         $_POST[$prefix.":minfraction"] = $qa->get_min_fraction();

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -690,32 +690,30 @@ class api extends external_api {
 
     /**
      * Implements the set_question_attempt_mark web service endpoint.
+     * Reference: mod/quiz/comment.php.
      *
-     * @param int $attemptid The question attempt ID.
+     * @param int $questionattemptid The question attempt ID.
      * @param string $mark The mark for this question attempt.
      * @param string|null $comment The comment for this question attempt (use null for new comment).
      * @return int A status flag
-     * @throws invalid_parameter_exception
      * @throws moodle_exception
+     * @throws invalid_parameter_exception
      */
-    public static function set_question_attempt_mark(int $attemptid, string $mark, $comment = null): int {
+    public static function set_question_attempt_mark(int $questionattemptid, string $mark, $comment = null): int {
         global $USER, $DB, $CFG;
         require_once($CFG->dirroot . '/lib/grade/constants.php');
-        require_once($CFG->dirroot . '/lib/modinfolib.php');
         require_once($CFG->dirroot . '/mod/quiz/locallib.php');
 
-        [
-            'attemptid' => $attemptid,
+        $params = [
+            'attemptid' => $questionattemptid,
             'mark' => $mark,
             'comment' => $comment,
-        ] = self::validate_parameters(self::set_question_attempt_mark_parameters(), [
-            'attemptid' => $attemptid,
-            'mark' => $mark,
-            'comment' => $comment,
-        ]);
+        ];
+        $params = self::validate_parameters(self::set_question_attempt_mark_parameters(), $params);
 
-        if (!isset($attemptid)) {
-            throw new \coding_exception('Invalid question attempt id');
+        // Prevent functions like file_get_submitted_draft_itemid() or form library requiring a sesskey for WS requests.
+        if (WS_SERVER || PHPUNIT_TEST) {
+            $USER->ignoresesskey = true;
         }
 
         // Find the quiz attempt id and the slot from question attempt id.
@@ -725,18 +723,18 @@ class api extends external_api {
                 FROM {quiz_attempts} qa
                 JOIN {question_attempts} qqa ON qa.uniqueid = qqa.questionusageid
                 WHERE qqa.id = ?;';
-        $qadata = $DB->get_record_sql($sql, [$attemptid]);
+        $qadata = $DB->get_record_sql($sql, [$questionattemptid]);
 
         // If $qadata is empty return error or exception.
         if (empty($qadata)) {
-            throw new \moodle_exception('Invalid question attempt ID.');
+            throw new \moodle_exception('invalidquestionid', 'quiz');
         }
+
         $quizattemptid = $qadata->qaid;
         $slot = $qadata->slot;
 
         $quizattemptobj = quiz_create_attempt_handling_errors($quizattemptid);
         $quizattemptobj->preload_all_attempt_step_users();
-        $student = $DB->get_record('user', ['id' => $quizattemptobj->get_userid()]);
 
         // Can only grade finished attempts.
         if (!$quizattemptobj->is_finished()) {
@@ -762,12 +760,10 @@ class api extends external_api {
         $_POST[$prefix.":minfraction"] = $qa->get_min_fraction();
         $_POST[$prefix.":maxfraction"] = $qa->get_max_fraction();
 
-        // Looks like I need to initialize these values, too.
+        // Set the comment text and format.
+        // See if there is a comment already.
         list($commenttext, $commentformat, $commentstep) = $qa->get_current_manual_comment();
-        if ($qa->has_manual_comment()) {
-            list($draftitemid, $commenttext) = $commentstep->prepare_response_files_draft_itemid_with_text(
-                'bf_comment', $quizattemptobj->get_quizobj()->get_context()->id, $commenttext);
-        } else if (!empty($commentstep)) {
+        if (!empty($commentstep)) {
                 list($draftitemid, $commenttext) = $commentstep->prepare_response_files_draft_itemid_with_text(
                 'bf_comment', $quizattemptobj->get_quizobj()->get_context()->id, $commenttext);
         } else {
@@ -777,11 +773,8 @@ class api extends external_api {
         $_POST[$prefix."-comment"] = $comment ?? $commenttext;
         $_POST[$prefix."-commentformat"] = $commentformat;  // Consider to use FORMAT_PLAIN, 2 (See lib/weblib.php L54).
         $_POST[$prefix."-comment:itemid"] = $draftitemid;
-        // This needs to be in $_REQUEST as well for the file picker to work. (ref. filelib.php L881).
+        // This needs to be in $_REQUEST as well for the file picker to work. (ref. lib/filelib.php L881).
         $_REQUEST[$prefix."-comment:itemid"] = $draftitemid;
-
-        // Brutally extract sesskey from $USER.
-        $_POST["sesskey"] = $USER->sesskey;
 
         // Process any data that was submitted.
         if (question_engine::is_manual_grade_in_range($quizattemptobj->get_uniqueid(), $slot)) {

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -498,6 +498,7 @@ class api extends external_api {
                     $questionattempt = $quba->get_question_attempt($slot);
                     $ret['questions'][] = [
                         'id' => $questionattempt->get_question_id(),
+                        'attemptid' => $questionattempt->get_database_id(),
                         'mark' => $questionattempt->get_mark(),
                         'answer' => util::format_string($questionattempt->get_response_summary(), $context),
                     ];
@@ -541,6 +542,7 @@ class api extends external_api {
                 'questions' => new external_multiple_structure(
                     new external_single_structure([
                         'id' => new external_value(PARAM_INT, 'Question ID', VALUE_REQUIRED),
+                        'attemptid' => new external_value(PARAM_INT, 'Question attempt ID', VALUE_REQUIRED),
                         'mark' => new external_value(PARAM_FLOAT, 'Mark received', VALUE_REQUIRED),
                         'answer' => new external_value(PARAM_RAW, 'Answer given', VALUE_REQUIRED),
                     ]),
@@ -665,6 +667,159 @@ class api extends external_api {
             "questionbankentryid $sql",
             $sqlparams,
             'id'
+        );
+    }
+
+    /**
+     * Defines the input parameters for the tool_ucsfsomapi_set_question_attempt_mark web service endpoint.
+     *
+     * @return external_function_parameters The parameter definition.
+     */
+    public static function set_question_attempt_mark_parameters(): external_function_parameters {
+        return new external_function_parameters(
+            [
+                'attemptid' => new external_value(PARAM_INT, 'The question attempt id to set mark.'),
+                'mark' => new external_value(PARAM_TEXT, 'Mark for this question attempt.'),
+                'comment'  => new external_value(PARAM_RAW, 'Grader\'s comment for this question attempt (optional)', VALUE_DEFAULT),
+             ]
+        );
+    }
+
+   /**
+     * Implements the set_question_attempt_mark web service endpoint.
+     *
+     * @param int $attemptid The question attempt ID.
+     * @param string $mark The mark for this question attempt.
+     * @return int A status flag
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     * @throws coding_exception
+     * @throws dml_exception
+     */
+    public static function set_question_attempt_mark(int $attemptid, string $mark, $comment = null): int {
+        global $USER, $DB, $CFG;
+        require_once($CFG->dirroot . '/lib/grade/constants.php');
+        require_once($CFG->dirroot . '/lib/modinfolib.php');
+        require_once($CFG->dirroot . '/mod/quiz/locallib.php');
+
+        [
+            'attemptid' => $attemptid,
+            'mark' => $mark,
+            'comment' => $comment,
+        ] = self::validate_parameters(self::set_question_attempt_mark_parameters(), [
+            'attemptid' => $attemptid,
+            'mark' => $mark,
+            'comment' => $comment,
+        ]);
+
+        if (!isset($attemptid)) {
+            throw new \coding_exception('Invalid question attempt id');
+        }
+
+        // Find the quiz attempt id and the slot from question attempt id.
+        $sql = 'SELECT  qa.id as qaid, 
+                        qqa.id as qqaid,
+                        qqa.slot as slot
+                FROM {quiz_attempts} qa
+                JOIN {question_attempts} qqa ON qa.uniqueid = qqa.questionusageid
+                WHERE qqa.id = ?;';
+        $qadata = $DB->get_record_sql($sql, [$attemptid]);
+
+        // If $qadata is empty return error or exception.
+        if (empty($qadata)) {
+            throw new \moodle_exception('Invalid question attempt ID.');
+        }
+        $quizattemptid = $qadata->qaid;
+        $slot = $qadata->slot;
+
+        $quizattemptobj = quiz_create_attempt_handling_errors($quizattemptid);
+        $quizattemptobj->preload_all_attempt_step_users();
+        $student = $DB->get_record('user', ['id' => $quizattemptobj->get_userid()]);
+
+        // Can only grade finished attempts.
+        if (!$quizattemptobj->is_finished()) {
+            throw new \moodle_exception('attemptclosed', 'quiz');
+        }
+
+        // Check login and permissions.
+        require_login($quizattemptobj->get_course(), false, $quizattemptobj->get_cm());
+        $quizattemptobj->require_capability('mod/quiz:grade');
+
+        // Set $_POST data.
+        //$prefix = $quizattemptobj->get_question_attempt($slot)->get_behaviour_field_name("");
+        $qa = $quizattemptobj->get_question_attempt($slot);
+        $prefix = $qa->get_field_prefix();
+
+        // Set the sequence check count to the latest value.
+        $_POST[$prefix.":sequencecheck"] = $qa->get_sequence_check_count();
+
+        $_POST["attempt"] = "$quizattemptid";
+        $_POST["slot"] = "$slot";
+        $_POST["slots"] = "$slot";      // This is set to $slot on comment.php line 122 (is this a bug?)
+        $_POST[$prefix."-mark"] = "$mark";
+        $_POST[$prefix."-maxmark"] = $qa->get_max_mark();
+        $_POST[$prefix.":minfraction"] = $qa->get_min_fraction();
+        $_POST[$prefix.":maxfraction"] = $qa->get_max_fraction();
+
+        // Looks like I need to initialize these values, too.
+        list($commenttext, $commentformat, $commentstep) = $qa->get_current_manual_comment();
+        if ($qa->has_manual_comment()) {
+            list($draftitemid, $commenttext) = $commentstep->prepare_response_files_draft_itemid_with_text(
+                'bf_comment', $quizattemptobj->get_quizobj()->get_context()->id, $commenttext);
+        } elseif (!empty($commentstep)) {
+                list($draftitemid, $commenttext) = $commentstep->prepare_response_files_draft_itemid_with_text(
+                'bf_comment', $quizattemptobj->get_quizobj()->get_context()->id, $commenttext);
+        } else {
+            $commenttext = '';
+            $draftitemid = file_get_unused_draft_itemid();
+        }
+        $_POST[$prefix."-comment"] = $comment ?? $commenttext;
+        $_POST[$prefix."-commentformat"] = $commentformat;  // consider to use FORMAT_PLAIN, 2 (See lib/weblib.php L54)
+        $_POST[$prefix."-comment:itemid"] = $draftitemid;
+        $_REQUEST[$prefix."-comment:itemid"] = $draftitemid;  // This needs to be in $_REQUEST as well for the file picker to work. (ref. filelib.php L881)
+
+        // Brutally extract sesskey from $USER
+        $_POST["sesskey"] = $USER->sesskey;
+
+        // Process any data that was submitted.
+        if (question_engine::is_manual_grade_in_range($quizattemptobj->get_uniqueid(), $slot)) {
+            $transaction = $DB->start_delegated_transaction();
+            $quizattemptobj->process_submitted_actions(time());
+            $transaction->allow_commit();
+
+            // Log this action.
+            $params = [
+                'objectid' => $quizattemptobj->get_question_attempt($slot)->get_question_id(),
+                'courseid' => $quizattemptobj->get_courseid(),
+                'context' => $quizattemptobj->get_quizobj()->get_context(),
+                'other' => [
+                    'quizid' => $quizattemptobj->get_quizid(),
+                    'attemptid' => $quizattemptobj->get_attemptid(),
+                    'slot' => $slot
+                ]
+            ];
+            $event = \mod_quiz\event\question_manually_graded::create($params);
+            $event->trigger();
+
+            return GRADE_UPDATE_OK;
+        } else {
+            return GRADE_UPDATE_FAILED;
+        }
+    }
+
+    /**
+     * Define the webservice response for set_question_attempt_mark.
+     *
+     * @return external_description|null always null.
+     */
+    public static function set_question_attempt_mark_returns(): ?external_description {
+        global $CFG;
+        require_once($CFG->dirroot . '/lib/grade/constants.php');
+
+        return new external_value(
+            PARAM_INT,
+            'A value like ' . GRADE_UPDATE_OK . ' => OK, '
+                    . GRADE_UPDATE_FAILED . ' => FAILED as defined in lib/grade/constants.php'
         );
     }
 }

--- a/classes/external/api.php
+++ b/classes/external/api.php
@@ -680,21 +680,23 @@ class api extends external_api {
             [
                 'attemptid' => new external_value(PARAM_INT, 'The question attempt id to set mark.'),
                 'mark' => new external_value(PARAM_TEXT, 'Mark for this question attempt.'),
-                'comment'  => new external_value(PARAM_RAW, 'Grader\'s comment for this question attempt (optional)', VALUE_DEFAULT),
+                'comment'  => new external_value(PARAM_RAW,
+                    'Grader\'s comment for this question attempt (optional)',
+                    VALUE_DEFAULT
+                ),
              ]
         );
     }
 
-   /**
+    /**
      * Implements the set_question_attempt_mark web service endpoint.
      *
      * @param int $attemptid The question attempt ID.
      * @param string $mark The mark for this question attempt.
+     * @param string|null $comment The comment for this question attempt (use null for new comment).
      * @return int A status flag
      * @throws invalid_parameter_exception
      * @throws moodle_exception
-     * @throws coding_exception
-     * @throws dml_exception
      */
     public static function set_question_attempt_mark(int $attemptid, string $mark, $comment = null): int {
         global $USER, $DB, $CFG;
@@ -717,7 +719,7 @@ class api extends external_api {
         }
 
         // Find the quiz attempt id and the slot from question attempt id.
-        $sql = 'SELECT  qa.id as qaid, 
+        $sql = 'SELECT  qa.id as qaid,
                         qqa.id as qqaid,
                         qqa.slot as slot
                 FROM {quiz_attempts} qa
@@ -746,7 +748,6 @@ class api extends external_api {
         $quizattemptobj->require_capability('mod/quiz:grade');
 
         // Set $_POST data.
-        //$prefix = $quizattemptobj->get_question_attempt($slot)->get_behaviour_field_name("");
         $qa = $quizattemptobj->get_question_attempt($slot);
         $prefix = $qa->get_field_prefix();
 
@@ -755,7 +756,7 @@ class api extends external_api {
 
         $_POST["attempt"] = "$quizattemptid";
         $_POST["slot"] = "$slot";
-        $_POST["slots"] = "$slot";      // This is set to $slot on comment.php line 122 (is this a bug?)
+        $_POST["slots"] = "$slot";      // This is set to $slot in /mod/quiz/comment.php, line 122 (is this a bug?).
         $_POST[$prefix."-mark"] = "$mark";
         $_POST[$prefix."-maxmark"] = $qa->get_max_mark();
         $_POST[$prefix.":minfraction"] = $qa->get_min_fraction();
@@ -766,7 +767,7 @@ class api extends external_api {
         if ($qa->has_manual_comment()) {
             list($draftitemid, $commenttext) = $commentstep->prepare_response_files_draft_itemid_with_text(
                 'bf_comment', $quizattemptobj->get_quizobj()->get_context()->id, $commenttext);
-        } elseif (!empty($commentstep)) {
+        } else if (!empty($commentstep)) {
                 list($draftitemid, $commenttext) = $commentstep->prepare_response_files_draft_itemid_with_text(
                 'bf_comment', $quizattemptobj->get_quizobj()->get_context()->id, $commenttext);
         } else {
@@ -774,11 +775,12 @@ class api extends external_api {
             $draftitemid = file_get_unused_draft_itemid();
         }
         $_POST[$prefix."-comment"] = $comment ?? $commenttext;
-        $_POST[$prefix."-commentformat"] = $commentformat;  // consider to use FORMAT_PLAIN, 2 (See lib/weblib.php L54)
+        $_POST[$prefix."-commentformat"] = $commentformat;  // Consider to use FORMAT_PLAIN, 2 (See lib/weblib.php L54).
         $_POST[$prefix."-comment:itemid"] = $draftitemid;
-        $_REQUEST[$prefix."-comment:itemid"] = $draftitemid;  // This needs to be in $_REQUEST as well for the file picker to work. (ref. filelib.php L881)
+        // This needs to be in $_REQUEST as well for the file picker to work. (ref. filelib.php L881).
+        $_REQUEST[$prefix."-comment:itemid"] = $draftitemid;
 
-        // Brutally extract sesskey from $USER
+        // Brutally extract sesskey from $USER.
         $_POST["sesskey"] = $USER->sesskey;
 
         // Process any data that was submitted.
@@ -795,8 +797,8 @@ class api extends external_api {
                 'other' => [
                     'quizid' => $quizattemptobj->get_quizid(),
                     'attemptid' => $quizattemptobj->get_attemptid(),
-                    'slot' => $slot
-                ]
+                    'slot' => $slot,
+                ],
             ];
             $event = \mod_quiz\event\question_manually_graded::create($params);
             $event->trigger();

--- a/db/services.php
+++ b/db/services.php
@@ -70,6 +70,24 @@ $functions = [
         'ajax' => false,
         'services' => ['ucsf_som_api'],
     ],
+    'tool_ucsfsomapi_set_question_attempt_mark' => [
+        'classname' => 'tool_ucsfsomapi\external\api',
+        'methodname' => 'set_question_attempt_mark',
+        'description' => 'Marks a given question attempt.',
+        'type' => 'write',
+        'capabilities' => 'mod/quiz:grade',
+        'ajax' => false,
+        'services' => ['ucsf_som_api'],
+    ],
+    'tool_ucsfsomapi_set_attempt_grade_data' => [
+        'classname' => 'tool_ucsfsomapi\external\api',
+        'methodname' => 'set_attempt_grade_data',
+        'description' => 'Sets a grade data for a given attempt.',
+        'type' => 'write',
+        'capabilities' => 'mod/quiz:grade',
+        'ajax' => false,
+        'services' => ['ucsf_som_api'],
+    ],
 ];
 
 $services = [

--- a/db/services.php
+++ b/db/services.php
@@ -79,15 +79,6 @@ $functions = [
         'ajax' => false,
         'services' => ['ucsf_som_api'],
     ],
-    'tool_ucsfsomapi_set_attempt_grade_data' => [
-        'classname' => 'tool_ucsfsomapi\external\api',
-        'methodname' => 'set_attempt_grade_data',
-        'description' => 'Sets a grade data for a given attempt.',
-        'type' => 'write',
-        'capabilities' => 'mod/quiz:grade',
-        'ajax' => false,
-        'services' => ['ucsf_som_api'],
-    ],
 ];
 
 $services = [

--- a/lang/en/tool_ucsfsomapi.php
+++ b/lang/en/tool_ucsfsomapi.php
@@ -21,7 +21,7 @@
  * @copyright  The Regents of the University of California
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-$string['eventquestionattemptmarked'] = 'Question attempt mark (and comment) updated';
-$string['eventsetquestionattemptmarkcalled'] = 'API: set_question_attempt_mark is called';
+$string['eventquestionattemptmarked'] = 'Question attempt graded';
+$string['eventsetquestionattemptmarkcalled'] = 'set_question_attempt_mark called';
 $string['pluginname'] = 'UCSF SOM API';
 $string['privacy:metadata'] = 'The UCSF SOM API plugin returns existing course, quiz, quiz-attempt, and user data.';

--- a/lang/en/tool_ucsfsomapi.php
+++ b/lang/en/tool_ucsfsomapi.php
@@ -21,5 +21,7 @@
  * @copyright  The Regents of the University of California
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+$string['eventquestionattemptmarked'] = 'Question attempt mark (and comment) updated';
+$string['eventsetquestionattemptmarkcalled'] = 'API: set_question_attempt_mark is called';
 $string['pluginname'] = 'UCSF SOM API';
 $string['privacy:metadata'] = 'The UCSF SOM API plugin returns existing course, quiz, quiz-attempt, and user data.';

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -1045,6 +1045,9 @@ final class api_test extends externallib_advanced_testcase {
         $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
         $attemptid = $qa->get_database_id();
 
+        // Catch the event.
+        $sink = $this->redirectEvents();
+
         // Call the API function with valid parameters.
         $result = external_api::clean_returnvalue(
             api::set_question_attempt_mark_returns(),
@@ -1052,6 +1055,25 @@ final class api_test extends externallib_advanced_testcase {
         );
         // Assert the result.
         $this->assertEquals(GRADE_UPDATE_OK, $result);
+
+        // Validate the events.
+        $events = $sink->get_events();
+        $sink->close();
+
+        // Check that the event count is correct.
+        $this->assertCount(1, $events);
+
+        // Validate the question_manually_graded event.
+        $event = $events[0];
+        $this->assertInstanceOf('\mod_quiz\event\question_manually_graded', $event);
+        $this->assertEquals('question', $event->objecttable);
+        $this->assertEquals($qa->get_question_id(), $event->objectid);
+        $this->assertEquals($course->id, $event->courseid);
+        $this->assertEquals($attemptobj->get_context(), $event->get_context());
+        $this->assertEquals($attempt->quiz, $event->other['quizid']); // Should be the user, but PHP Unit complains...
+        $this->assertEquals($attempt->id, $event->other['attemptid']); // Should be the user, but PHP Unit complains...
+        $this->assertEquals($qa->get_slot(), $event->other['slot']); // Should be the user, but PHP Unit complains...
+        $this->assertEventContextNotUsed($event);
 
         // Check the database to ensure the mark was set correctly.
         $sql = 'SELECT qasd.*

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -845,11 +845,17 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEquals($timefinish1, $rhett[0]['timefinish']);
         $this->assertCount(2, $rhett[0]['questions']);
         $this->assertEquals($question1->id, $rhett[0]['questions'][0]['id']);
-        $this->assertEquals($attemptobj1->get_question_usage()->get_question_attempt(1)->get_database_id(), $rhett[0]['questions'][0]['attemptid']);
+        $this->assertEquals(
+            $attemptobj1->get_question_usage()->get_question_attempt(1)->get_database_id(),
+            $rhett[0]['questions'][0]['attemptid']
+        );
         $this->assertEquals(1.0, $rhett[0]['questions'][0]['mark']); // Correct answer.
         $this->assertEquals($answers1[1], $rhett[0]['questions'][0]['answer']);
         $this->assertEquals($question2->id, $rhett[0]['questions'][1]['id']);
-        $this->assertEquals($attemptobj1->get_question_usage()->get_question_attempt(2)->get_database_id(), $rhett[0]['questions'][1]['attemptid']);
+        $this->assertEquals(
+            $attemptobj1->get_question_usage()->get_question_attempt(2)->get_database_id(),
+            $rhett[0]['questions'][1]['attemptid']
+        );
         $this->assertEquals(0.0, $rhett[0]['questions'][1]['mark']); // Wrong answer.
         $this->assertEquals($answers1[2], $rhett[0]['questions'][1]['answer']);
 
@@ -860,11 +866,17 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEquals($timefinish2, $rhett[1]['timefinish']);
         $this->assertCount(2, $rhett[1]['questions']);
         $this->assertEquals($question1->id, $rhett[1]['questions'][0]['id']);
-        $this->assertEquals($attemptobj2->get_question_usage()->get_question_attempt(1)->get_database_id(), $rhett[1]['questions'][0]['attemptid']);
+        $this->assertEquals(
+            $attemptobj2->get_question_usage()->get_question_attempt(1)->get_database_id(),
+            $rhett[1]['questions'][0]['attemptid']
+        );
         $this->assertEquals(0.0, $rhett[1]['questions'][0]['mark']); // Wrong answer.
         $this->assertEquals($answers2[1], $rhett[1]['questions'][0]['answer']);
         $this->assertEquals($question2->id, $rhett[1]['questions'][1]['id']);
-        $this->assertEquals($attemptobj2->get_question_usage()->get_question_attempt(2)->get_database_id(), $rhett[1]['questions'][1]['attemptid']);
+        $this->assertEquals(
+            $attemptobj2->get_question_usage()->get_question_attempt(2)->get_database_id(),
+            $rhett[1]['questions'][1]['attemptid']
+        );
         $this->assertEquals(1.0, $rhett[1]['questions'][1]['mark']); // Correct answer.
         $this->assertEquals($answers2[2], $rhett[1]['questions'][1]['answer']);
     }
@@ -1001,7 +1013,6 @@ final class api_test extends externallib_advanced_testcase {
         $this->setAdminUser();
         [$course, $quiz] = $this->create_course_and_quiz();
         $question = $this->create_question($quiz);
-        // $attemptid = $this->create_quiz_attempt($quiz, $student);
 
         // Retrieve attempts for the quiz, should come up empty-handed.
         $result = external_api::clean_returnvalue(
@@ -1068,7 +1079,7 @@ final class api_test extends externallib_advanced_testcase {
      * It then calls the API function with an invalid attempt ID and verifies that
      * the expected exception is thrown.
      */
-    public function test_set_question_attempt_mark_invalid_attemptid() {
+    public function test_set_question_attempt_mark_invalid_attemptid(): void {
         global $DB;
 
         // Expect an exception when calling the API with an invalid attempt ID.
@@ -1083,7 +1094,7 @@ final class api_test extends externallib_advanced_testcase {
     /**
      * Test set_question_attempt_mark with invalid mark.
      */
-    public function test_set_question_attempt_mark_invalid_mark() {
+    public function test_set_question_attempt_mark_invalid_mark(): void {
         global $DB;
 
         // Set up the test environment.
@@ -1135,14 +1146,13 @@ final class api_test extends externallib_advanced_testcase {
     /**
      * Test set_question_attempt_mark with invalid comment.
      */
-    public function test_set_question_attempt_mark_invalid_comment() {
+    public function test_set_question_attempt_mark_invalid_comment(): void {
         global $DB;
 
         // Set up the test environment.
         $this->setAdminUser();
         [$course, $quiz] = $this->create_course_and_quiz();
         $question = $this->create_question($quiz);
-
 
         // Retrieve attempts for the quiz, should come up empty-handed.
         $result = external_api::clean_returnvalue(
@@ -1175,22 +1185,26 @@ final class api_test extends externallib_advanced_testcase {
         $attemptid = $qa->get_database_id();
 
         // Call the method with an invalid comment.
+        $invalidcomment = "\0Invalid\0Comment";
         $this->expectException(\moodle_exception::class);
-        $this->expectExceptionMessage('Invalid parameter value detected (Invalid external api parameter: the value is " Invalid Comment", the server was expecting "raw" type): Invalid external api parameter: the value is " Invalid Comment", the server was expecting "raw" type');
+        $this->expectExceptionMessage(
+            'Invalid parameter value detected (Invalid external api parameter: '
+            .'the value is "' . $invalidcomment . '", the server was expecting "raw" type): '
+            .'Invalid external api parameter: the value is "' . $invalidcomment . '", '
+            .'the server was expecting "raw" type'
+        );
 
         // Call the API function with valid parameters.
         $result = external_api::clean_returnvalue(
             api::set_question_attempt_mark_returns(),
-            api::set_question_attempt_mark($attemptid, '1.0', "\0Invalid\0Comment")
-            // api::set_question_attempt_mark($attemptid, '1.0', null)
-            // api::set_question_attempt_mark($attemptid, '1.0', str_repeat('a', 10001))
+            api::set_question_attempt_mark($attemptid, '1.0', $invalidcomment)
         );
     }
 
     /**
      * Test set_question_attempt_mark with unfinished attempt.
      */
-    public function test_set_question_attempt_mark_unfinished_attempt() {
+    public function test_set_question_attempt_mark_unfinished_attempt(): void {
         global $DB;
 
         $this->resetAfterTest(true);
@@ -1234,7 +1248,7 @@ final class api_test extends externallib_advanced_testcase {
     /**
      * Test set_question_attempt_mark with missing 'mod/quiz:grade' capability.
      */
-    public function test_set_question_attempt_mark_missing_quiz_grade_capability() {
+    public function test_set_question_attempt_mark_missing_quiz_grade_capability(): void {
         global $DB;
 
         $this->resetAfterTest(true);
@@ -1245,7 +1259,6 @@ final class api_test extends externallib_advanced_testcase {
         // Create a mock quiz attempt and question attempt.
         [$course, $quiz] = $this->create_course_and_quiz();
         $question = $this->create_question($quiz);
-
 
         // Retrieve attempts for the quiz, should come up empty-handed.
         $result = external_api::clean_returnvalue(
@@ -1326,7 +1339,10 @@ final class api_test extends externallib_advanced_testcase {
         // Create a course.
         $course = $this->getDataGenerator()->create_course();
         // Get a hold of the quiz module contexts.
-        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id, 'name' => 'Sample Quiz', 'sumgrades' => 1]);
+        $quiz = $this->getDataGenerator()->create_module(
+            'quiz',
+            ['course' => $course->id, 'name' => 'Sample Quiz', 'sumgrades' => 1]
+        );
 
         return [$course, $quiz];
     }
@@ -1353,7 +1369,6 @@ final class api_test extends externallib_advanced_testcase {
      */
     private function create_student_and_enroll($course): object {
         $student = $this->getDataGenerator()->create_user();
-        //$studentrole = $DB->get_record('role', ['shortname' => 'student']);
         $this->getDataGenerator()->enrol_user($student->id, $course->id, 'student');
         return $student;
     }

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -1023,6 +1023,12 @@ final class api_test extends externallib_advanced_testcase {
         // Catch the event.
         $sink = $this->redirectEvents();
 
+        // Enter some dummy data in $_GET and $_POST to confirm they are captured in the events.
+        $_GET['data'] = 'GET test data';
+        $_GET['wstoken'] = '0123456789';
+        $_POST['data'] = 'POST test data';
+        $_POST['wstoken'] = '1234567890';
+
         // Call the API function with valid parameters.
         $result = external_api::clean_returnvalue(
             api::set_question_attempt_mark_returns(),
@@ -1038,7 +1044,7 @@ final class api_test extends externallib_advanced_testcase {
         // Check that the event count is correct.
         $this->assertCount(4, $events);
 
-        // Validate the call_to_set_question_attempt_mark_api event.
+        // Validate the set_question_attempt_mark_called event.
         $event = $events[0];
         $this->assertInstanceOf('\tool_ucsfsomapi\event\set_question_attempt_mark_called', $event);
         $this->assertEquals('question', $event->objecttable);
@@ -1046,9 +1052,11 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEquals(\context_system::instance(), $event->get_context());
         $this->assertEquals('1', $event->other['mark']);
         $this->assertEquals('Good job!', $event->other['comment']);
+        $this->assertEquals('{"data":"GET test data","wstoken":"0*****6789"}', $event->other['GET']);
+        $this->assertEquals('{"data":"POST test data","wstoken":"1*****7890"}', $event->other['POST']);
         $this->assertEventContextNotUsed($event);
 
-        // Validate the question_manually_graded event.
+        // Validate the question_attempt_marked event.
         $event = $events[3];
         $this->assertInstanceOf('\tool_ucsfsomapi\event\question_attempt_marked', $event);
         $this->assertEquals('question', $event->objecttable);

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -1034,7 +1034,7 @@ final class api_test extends externallib_advanced_testcase {
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
             $attemptobj->get_question_usage(),
-            [1 => 'True'],
+            [1 => 'Sample answer.'],
             true,
         );
         $attemptobj->process_submitted_actions(time(), false, $postdata);
@@ -1061,7 +1061,7 @@ final class api_test extends externallib_advanced_testcase {
         $sink->close();
 
         // Check that the event count is correct.
-        $this->assertCount(2, $events);
+        $this->assertCount(4, $events);
 
         // Validate the call_to_set_question_attempt_mark_api event.
         $event = $events[0];
@@ -1074,7 +1074,7 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEventContextNotUsed($event);
 
         // Validate the question_manually_graded event.
-        $event = $events[1];
+        $event = $events[3];
         $this->assertInstanceOf('\tool_ucsfsomapi\event\question_attempt_marked', $event);
         $this->assertEquals('question', $event->objecttable);
         $this->assertEquals($qa->get_question_id(), $event->objectid);
@@ -1094,6 +1094,9 @@ final class api_test extends externallib_advanced_testcase {
         $params = ['qaid' => $attemptid, 'markingfield' => '-mark'];
         $qasd = $DB->get_record_sql($sql, $params);
 
+        // Ensure the query result is valid.
+        $this->assertNotFalse($qasd, 'Failed to retrieve the expected question attempt step data.');
+
         // Assert mark in the database.
         $this->assertEquals(1.0, $qasd->value);
 
@@ -1102,6 +1105,106 @@ final class api_test extends externallib_advanced_testcase {
         $qasd = $DB->get_record_sql($sql, $params);
 
         $this->assertEquals('Good job!', $qasd->value);
+    }
+
+    /** Tests the "set_question_attempt_mark" endpoint with just mark, no comment.
+     *
+     * This test creates a course, a quiz module, and a dummy quiz attempt record.
+     * It then calls the API function with only mark being set (no comment) and
+     * verifies that the expected result is returned.
+     */
+    public function test_set_question_attempt_mark_with_no_comment(): void {
+        global $DB;
+
+        // Set up the test environment.
+        $this->setAdminUser();
+        [$course, $quiz] = $this->create_course_and_quiz();
+        $question = $this->create_question($quiz);
+
+        // Retrieve attempts for the quiz, should come up empty-handed.
+        $result = external_api::clean_returnvalue(
+            api::get_attempts_returns(),
+            api::get_attempts([$quiz->id])
+        );
+        $this->assertEmpty($result);
+
+        // Create a user and enroll them as student in the course.
+        $student = $this->create_student_and_enroll($course);
+
+        // Create a dummy quiz attempt record.
+        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
+
+        // Answer the question
+        // @see /mod/quiz/tests/external/external_test.php for reference.
+        $attemptobj = quiz_attempt::create($attempt->id);
+
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
+            $attemptobj->get_question_usage(),
+            [1 => 'Sample answer.'],
+            true,
+        );
+        $attemptobj->process_submitted_actions(time(), false, $postdata);
+        // Finish the attempt.
+        $attemptobj->process_attempt(time(), true, false, 1);
+
+        // Get the question attempt ID.
+        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $attemptid = $qa->get_database_id();
+
+        // Catch the event.
+        $sink = $this->redirectEvents();
+
+        // Call the API function with valid parameters (no comment).
+        $result = external_api::clean_returnvalue(
+            api::set_question_attempt_mark_returns(),
+            api::set_question_attempt_mark($attemptid, 1.0)
+        );
+        // Assert the result.
+        $this->assertEquals(GRADE_UPDATE_OK, $result);
+
+        // Validate the events.
+        $events = $sink->get_events();
+        $sink->close();
+
+        // Check that the event count is correct.
+        $this->assertCount(4, $events);
+
+        // Validate the call_to_set_question_attempt_mark_api event.
+        $event = $events[0];
+        $this->assertInstanceOf('\tool_ucsfsomapi\event\set_question_attempt_mark_called', $event);
+        $this->assertEquals('question', $event->objecttable);
+        $this->assertEquals($attemptid, $event->objectid);
+        $this->assertEquals(\context_system::instance(), $event->get_context());
+        $this->assertEquals('1', $event->other['mark']);
+        $this->assertEventContextNotUsed($event);
+
+        // Validate the question_manually_graded event.
+        $event = $events[3];
+        $this->assertInstanceOf('\tool_ucsfsomapi\event\question_attempt_marked', $event);
+        $this->assertEquals('question', $event->objecttable);
+        $this->assertEquals($qa->get_question_id(), $event->objectid);
+        $this->assertEquals($course->id, $event->courseid);
+        $this->assertEquals($attemptobj->get_context(), $event->get_context());
+        $this->assertEquals($attempt->quiz, $event->other['quizid']);
+        $this->assertEquals($attempt->id, $event->other['attemptid']);
+        $this->assertEquals($qa->get_slot(), $event->other['slot']);
+        $this->assertEventContextNotUsed($event);
+
+        // Check the database to ensure the mark was set correctly.
+        $sql = 'SELECT qasd.*
+                FROM {question_attempt_steps} qas
+                JOIN {question_attempt_step_data} qasd ON qasd.attemptstepid = qas.id
+                WHERE qas.questionattemptid = :qaid AND qasd.name = :markingfield
+                ORDER BY qas.sequencenumber DESC LIMIT 1';
+        $params = ['qaid' => $attemptid, 'markingfield' => '-mark'];
+        $qasd = $DB->get_record_sql($sql, $params);
+
+        // Ensure the query result is valid.
+        $this->assertNotFalse($qasd, 'Failed to retrieve the expected question attempt step data.');
+
+        // Assert mark in the database.
+        $this->assertEquals(1.0, $qasd->value);
     }
 
     /**
@@ -1388,7 +1491,7 @@ final class api_test extends externallib_advanced_testcase {
     private function create_question($quiz): object {
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $category = $questiongenerator->create_question_category();
-        $question = $questiongenerator->create_question('truefalse', null, ['category' => $category->id]);
+        $question = $questiongenerator->create_question('essay', null, ['category' => $category->id]);
         quiz_add_quiz_question($question->id, $quiz);
         return $question;
     }

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -1084,7 +1084,7 @@ final class api_test extends externallib_advanced_testcase {
 
         // Expect an exception when calling the API with an invalid attempt ID.
         $this->expectException(\moodle_exception::class);
-        $this->expectExceptionMessage('Invalid question attempt ID.');
+        $this->expectExceptionMessage('Invalid question id');
 
         // Call the method with an invalid attempt ID.
         api::set_question_attempt_mark(0, '1.0', 'Invalid attempt');

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -1025,25 +1025,25 @@ final class api_test extends externallib_advanced_testcase {
         $student = $this->create_student_and_enroll($course);
 
         // Create a dummy quiz attempt record.
-        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
+        $quizattempt = $this->create_and_start_quiz_attempt($quiz, $student);
 
         // Answer the question
         // @see /mod/quiz/tests/external/external_test.php for reference.
-        $attemptobj = quiz_attempt::create($attempt->id);
+        $quizattemptobj = quiz_attempt::create($quizattempt->id);
 
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
-            $attemptobj->get_question_usage(),
+            $quizattemptobj->get_question_usage(),
             [1 => 'Sample answer.'],
             true,
         );
-        $attemptobj->process_submitted_actions(time(), false, $postdata);
+        $quizattemptobj->process_submitted_actions(time(), false, $postdata);
         // Finish the attempt.
-        $attemptobj->process_attempt(time(), true, false, 1);
+        $quizattemptobj->process_attempt(time(), true, false, 1);
 
         // Get the question attempt ID.
-        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
-        $attemptid = $qa->get_database_id();
+        $qa = $quizattemptobj->get_question_usage()->get_question_attempt(1);
+        $questionattemptid = $qa->get_database_id();
 
         // Catch the event.
         $sink = $this->redirectEvents();
@@ -1051,7 +1051,7 @@ final class api_test extends externallib_advanced_testcase {
         // Call the API function with valid parameters.
         $result = external_api::clean_returnvalue(
             api::set_question_attempt_mark_returns(),
-            api::set_question_attempt_mark($attemptid, 1.0, 'Good job!')
+            api::set_question_attempt_mark($questionattemptid, 1.0, 'Good job!')
         );
         // Assert the result.
         $this->assertEquals(GRADE_UPDATE_OK, $result);
@@ -1067,7 +1067,7 @@ final class api_test extends externallib_advanced_testcase {
         $event = $events[0];
         $this->assertInstanceOf('\tool_ucsfsomapi\event\set_question_attempt_mark_called', $event);
         $this->assertEquals('question', $event->objecttable);
-        $this->assertEquals($attemptid, $event->objectid);
+        $this->assertEquals($questionattemptid, $event->objectid);
         $this->assertEquals(\context_system::instance(), $event->get_context());
         $this->assertEquals('1', $event->other['mark']);
         $this->assertEquals('Good job!', $event->other['comment']);
@@ -1079,9 +1079,9 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEquals('question', $event->objecttable);
         $this->assertEquals($qa->get_question_id(), $event->objectid);
         $this->assertEquals($course->id, $event->courseid);
-        $this->assertEquals($attemptobj->get_context(), $event->get_context());
-        $this->assertEquals($attempt->quiz, $event->other['quizid']);
-        $this->assertEquals($attempt->id, $event->other['attemptid']);
+        $this->assertEquals($quizattemptobj->get_context(), $event->get_context());
+        $this->assertEquals($quizattempt->quiz, $event->other['quizid']);
+        $this->assertEquals($quizattempt->id, $event->other['attemptid']);
         $this->assertEquals($qa->get_slot(), $event->other['slot']);
         $this->assertEventContextNotUsed($event);
 
@@ -1091,7 +1091,7 @@ final class api_test extends externallib_advanced_testcase {
                 JOIN {question_attempt_step_data} qasd ON qasd.attemptstepid = qas.id
                 WHERE qas.questionattemptid = :qaid AND qasd.name = :markingfield
                 ORDER BY qas.sequencenumber DESC LIMIT 1';
-        $params = ['qaid' => $attemptid, 'markingfield' => '-mark'];
+        $params = ['qaid' => $questionattemptid, 'markingfield' => '-mark'];
         $qasd = $DB->get_record_sql($sql, $params);
 
         // Ensure the query result is valid.
@@ -1101,7 +1101,7 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEquals(1.0, $qasd->value);
 
         // Assert comment in the database.
-        $params = ['qaid' => $attemptid, 'markingfield' => '-comment'];
+        $params = ['qaid' => $questionattemptid, 'markingfield' => '-comment'];
         $qasd = $DB->get_record_sql($sql, $params);
 
         $this->assertEquals('Good job!', $qasd->value);
@@ -1132,25 +1132,25 @@ final class api_test extends externallib_advanced_testcase {
         $student = $this->create_student_and_enroll($course);
 
         // Create a dummy quiz attempt record.
-        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
+        $quizattempt = $this->create_and_start_quiz_attempt($quiz, $student);
 
         // Answer the question
         // @see /mod/quiz/tests/external/external_test.php for reference.
-        $attemptobj = quiz_attempt::create($attempt->id);
+        $quizattemptobj = quiz_attempt::create($quizattempt->id);
 
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
-            $attemptobj->get_question_usage(),
+            $quizattemptobj->get_question_usage(),
             [1 => 'Sample answer.'],
             true,
         );
-        $attemptobj->process_submitted_actions(time(), false, $postdata);
+        $quizattemptobj->process_submitted_actions(time(), false, $postdata);
         // Finish the attempt.
-        $attemptobj->process_attempt(time(), true, false, 1);
+        $quizattemptobj->process_attempt(time(), true, false, 1);
 
         // Get the question attempt ID.
-        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
-        $attemptid = $qa->get_database_id();
+        $qa = $quizattemptobj->get_question_usage()->get_question_attempt(1);
+        $questionattemptid = $qa->get_database_id();
 
         // Catch the event.
         $sink = $this->redirectEvents();
@@ -1158,7 +1158,7 @@ final class api_test extends externallib_advanced_testcase {
         // Call the API function with valid parameters (no comment).
         $result = external_api::clean_returnvalue(
             api::set_question_attempt_mark_returns(),
-            api::set_question_attempt_mark($attemptid, 1.0)
+            api::set_question_attempt_mark($questionattemptid, 1.0)
         );
         // Assert the result.
         $this->assertEquals(GRADE_UPDATE_OK, $result);
@@ -1174,9 +1174,10 @@ final class api_test extends externallib_advanced_testcase {
         $event = $events[0];
         $this->assertInstanceOf('\tool_ucsfsomapi\event\set_question_attempt_mark_called', $event);
         $this->assertEquals('question', $event->objecttable);
-        $this->assertEquals($attemptid, $event->objectid);
+        $this->assertEquals($questionattemptid, $event->objectid);
         $this->assertEquals(\context_system::instance(), $event->get_context());
         $this->assertEquals('1', $event->other['mark']);
+        $this->assertNotContains('comment', $event->other);
         $this->assertEventContextNotUsed($event);
 
         // Validate the question_manually_graded event.
@@ -1185,9 +1186,9 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEquals('question', $event->objecttable);
         $this->assertEquals($qa->get_question_id(), $event->objectid);
         $this->assertEquals($course->id, $event->courseid);
-        $this->assertEquals($attemptobj->get_context(), $event->get_context());
-        $this->assertEquals($attempt->quiz, $event->other['quizid']);
-        $this->assertEquals($attempt->id, $event->other['attemptid']);
+        $this->assertEquals($quizattemptobj->get_context(), $event->get_context());
+        $this->assertEquals($quizattempt->quiz, $event->other['quizid']);
+        $this->assertEquals($quizattempt->id, $event->other['attemptid']);
         $this->assertEquals($qa->get_slot(), $event->other['slot']);
         $this->assertEventContextNotUsed($event);
 
@@ -1197,7 +1198,7 @@ final class api_test extends externallib_advanced_testcase {
                 JOIN {question_attempt_step_data} qasd ON qasd.attemptstepid = qas.id
                 WHERE qas.questionattemptid = :qaid AND qasd.name = :markingfield
                 ORDER BY qas.sequencenumber DESC LIMIT 1';
-        $params = ['qaid' => $attemptid, 'markingfield' => '-mark'];
+        $params = ['qaid' => $questionattemptid, 'markingfield' => '-mark'];
         $qasd = $DB->get_record_sql($sql, $params);
 
         // Ensure the query result is valid.

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -1011,35 +1011,10 @@ final class api_test extends externallib_advanced_testcase {
 
         // Set up the test environment.
         $this->setAdminUser();
-        [$course, $quiz] = $this->create_course_and_quiz();
-        $question = $this->create_question($quiz);
 
-        // Retrieve attempts for the quiz, should come up empty-handed.
-        $result = external_api::clean_returnvalue(
-            api::get_attempts_returns(),
-            api::get_attempts([$quiz->id])
-        );
-        $this->assertEmpty($result);
-
-        // Create a user and enroll them as student in the course.
-        $student = $this->create_student_and_enroll($course);
-
-        // Create a dummy quiz attempt record.
-        $quizattempt = $this->create_and_start_quiz_attempt($quiz, $student);
-
-        // Answer the question
-        // @see /mod/quiz/tests/external/external_test.php for reference.
-        $quizattemptobj = quiz_attempt::create($quizattempt->id);
-
-        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
-        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
-            $quizattemptobj->get_question_usage(),
-            [1 => 'Sample answer.'],
-            true,
-        );
-        $quizattemptobj->process_submitted_actions(time(), false, $postdata);
-        // Finish the attempt.
-        $quizattemptobj->process_attempt(time(), true, false, 1);
+        // Create a course, a quiz module, and a dummy quiz attempt record.
+        [$course, $quiz, $context, $quizobj, $quizattempt, $quizattemptobj, $quba]
+            = $this->create_course_with_quiz_with_questions(true, true);
 
         // Get the question attempt ID.
         $qa = $quizattemptobj->get_question_usage()->get_question_attempt(1);
@@ -1118,35 +1093,10 @@ final class api_test extends externallib_advanced_testcase {
 
         // Set up the test environment.
         $this->setAdminUser();
-        [$course, $quiz] = $this->create_course_and_quiz();
-        $question = $this->create_question($quiz);
 
-        // Retrieve attempts for the quiz, should come up empty-handed.
-        $result = external_api::clean_returnvalue(
-            api::get_attempts_returns(),
-            api::get_attempts([$quiz->id])
-        );
-        $this->assertEmpty($result);
-
-        // Create a user and enroll them as student in the course.
-        $student = $this->create_student_and_enroll($course);
-
-        // Create a dummy quiz attempt record.
-        $quizattempt = $this->create_and_start_quiz_attempt($quiz, $student);
-
-        // Answer the question
-        // @see /mod/quiz/tests/external/external_test.php for reference.
-        $quizattemptobj = quiz_attempt::create($quizattempt->id);
-
-        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
-        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
-            $quizattemptobj->get_question_usage(),
-            [1 => 'Sample answer.'],
-            true,
-        );
-        $quizattemptobj->process_submitted_actions(time(), false, $postdata);
-        // Finish the attempt.
-        $quizattemptobj->process_attempt(time(), true, false, 1);
+        // Create a course, a quiz module, and a dummy quiz attempt record.
+        [$course, $quiz, $context, $quizobj, $quizattempt, $quizattemptobj, $quba]
+            = $this->create_course_with_quiz_with_questions(true, true);
 
         // Get the question attempt ID.
         $qa = $quizattemptobj->get_question_usage()->get_question_attempt(1);
@@ -1235,38 +1185,13 @@ final class api_test extends externallib_advanced_testcase {
 
         // Set up the test environment.
         $this->setAdminUser();
-        [$course, $quiz] = $this->create_course_and_quiz();
-        $question = $this->create_question($quiz);
 
-        // Retrieve attempts for the quiz, should come up empty-handed.
-        $result = external_api::clean_returnvalue(
-            api::get_attempts_returns(),
-            api::get_attempts([$quiz->id])
-        );
-        $this->assertEmpty($result);
-
-        // Create a user and enroll them as student in the course.
-        $student = $this->create_student_and_enroll($course);
-
-        // Create a dummy quiz attempt record.
-        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
-
-        // Answer the question
-        // @see /mod/quiz/tests/external/external_test.php for reference.
-        $attemptobj = quiz_attempt::create($attempt->id);
-        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
-
-        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
-            $attemptobj->get_question_usage(),
-            [1 => 'True'],
-            true,
-        );
-        $attemptobj->process_submitted_actions(time(), false, $postdata);
-        // Finish the attempt.
-        $attemptobj->process_attempt(time(), true, false, 1);
+        // Create a course, a quiz module, and a dummy quiz attempt record.
+        [$course, $quiz, $context, $quizobj, $quizattempt, $quizattemptobj, $quba]
+            = $this->create_course_with_quiz_with_questions(true, true);
 
         // Get the question attempt ID.
-        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $qa = $quizattemptobj->get_question_usage()->get_question_attempt(1);
         $attemptid = $qa->get_database_id();
 
         // Call the API function with valid parameters.
@@ -1287,37 +1212,12 @@ final class api_test extends externallib_advanced_testcase {
 
         // Set up the test environment.
         $this->setAdminUser();
-        [$course, $quiz] = $this->create_course_and_quiz();
-        $question = $this->create_question($quiz);
-
-        // Retrieve attempts for the quiz, should come up empty-handed.
-        $result = external_api::clean_returnvalue(
-            api::get_attempts_returns(),
-            api::get_attempts([$quiz->id])
-        );
-        $this->assertEmpty($result);
-
-        // Create a user and enroll them as student in the course.
-        $student = $this->create_student_and_enroll($course);
-
-        // Create a dummy quiz attempt record.
-        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
-
-        // Answer the question
-        // @see /mod/quiz/tests/external/external_test.php for reference.
-        $attemptobj = quiz_attempt::create($attempt->id);
-        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
-        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
-            $attemptobj->get_question_usage(),
-            [1 => 'True'],
-            true,
-        );
-        $attemptobj->process_submitted_actions(time(), false, $postdata);
-        // Finish the attempt.
-        $attemptobj->process_attempt(time(), true, false, 1);
+        // Create a course, a quiz module, and a dummy quiz attempt record.
+        [$course, $quiz, $context, $quizobj, $quizattempt, $quizattemptobj, $quba]
+            = $this->create_course_with_quiz_with_questions(true, true);
 
         // Get the question attempt ID.
-        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $qa = $quizattemptobj->get_question_usage()->get_question_attempt(1);
         $attemptid = $qa->get_database_id();
 
         // Call the method with an invalid comment.
@@ -1343,32 +1243,15 @@ final class api_test extends externallib_advanced_testcase {
     public function test_set_question_attempt_mark_unfinished_attempt(): void {
         global $DB;
 
-        $this->resetAfterTest(true);
+        // Set up the test environment.
+        $this->setAdminUser();
 
-        // Create a mock quiz attempt and question attempt.
-        [$course, $quiz] = $this->create_course_and_quiz();
-        $question = $this->create_question($quiz);
-
-        // Create a user and enroll them as student in the course.
-        $student = $this->create_student_and_enroll($course);
-
-        // Create a dummy quiz attempt record.
-        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
-
-        // Answer the question
-        // @see /mod/quiz/tests/external/external_test.php for reference.
-        $attemptobj = quiz_attempt::create($attempt->id);
-        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
-
-        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
-            $attemptobj->get_question_usage(),
-            [1 => 'True'],
-            true,
-        );
-        $attemptobj->process_submitted_actions(time(), false, $postdata);
+        // Create a course, a quiz module, and a dummy quiz attempt record.
+        [$course, $quiz, $context, $quizobj, $quizattempt, $quizattemptobj, $quba]
+            = $this->create_course_with_quiz_with_questions(true, false);
 
         // Get the question attempt ID.
-        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $qa = $quizattemptobj->get_question_usage()->get_question_attempt(1);
         $attemptid = $qa->get_database_id();
 
         $this->expectException(\moodle_exception::class);
@@ -1387,45 +1270,15 @@ final class api_test extends externallib_advanced_testcase {
     public function test_set_question_attempt_mark_missing_quiz_grade_capability(): void {
         global $DB;
 
-        $this->resetAfterTest(true);
-
         // Set up the test environment.
         $this->setAdminUser();
 
-        // Create a mock quiz attempt and question attempt.
-        [$course, $quiz] = $this->create_course_and_quiz();
-        $question = $this->create_question($quiz);
-
-        // Retrieve attempts for the quiz, should come up empty-handed.
-        $result = external_api::clean_returnvalue(
-            api::get_attempts_returns(),
-            api::get_attempts([$quiz->id])
-        );
-        $this->assertEmpty($result);
-
-        // Create a user and enroll them as student in the course.
-        $student = $this->create_student_and_enroll($course);
-
-        // Create a dummy quiz attempt record.
-        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
-
-        // Answer the question
-        // @see /mod/quiz/tests/external/external_test.php for reference.
-        $attemptobj = quiz_attempt::create($attempt->id);
-
-        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
-        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
-            $attemptobj->get_question_usage(),
-            [1 => 'True'],
-            true,
-        );
-        $attemptobj->process_submitted_actions(time(), false, $postdata);
-
-        // Finish the attempt.
-        $attemptobj->process_attempt(time(), true, false, 1);
+        // Create a course, a quiz module, and a dummy quiz attempt record.
+        [$course, $quiz, $context, $quizobj, $quizattempt, $quizattemptobj, $quba]
+            = $this->create_course_with_quiz_with_questions(true, true);
 
         // Get the question attempt ID.
-        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $qa = $quizattemptobj->get_question_usage()->get_question_attempt(1);
         $attemptid = $qa->get_database_id();
 
         // Create a user and attempt to set a mark without proper permissions.
@@ -1462,69 +1315,106 @@ final class api_test extends externallib_advanced_testcase {
     }
 
     /**
-     * Helper methods for common setup tasks.
-     */
-
-    /**
-     * Create a course and a quiz module.
+     * Create a course with a quiz with questions including a started or finished attempt optionally
      *
-     * @return array The created course and quiz objects.
+     * @param  boolean $startattempt whether to start a new attempt
+     * @param  boolean $finishattempt whether to finish the new attempt
+     * @param  string $behaviour the quiz preferredbehaviour, defaults to 'deferredfeedback'.
+     * @param  boolean $includeqattachments whether to include a question that supports attachments, defaults to false.
+     * @param  array $extraoptions extra options for Quiz.
+     * @return array array containing the course, quiz, context and the attempt
      */
-    private function create_course_and_quiz(): array {
+    private function create_course_with_quiz_with_questions(
+        $startattempt = false,
+        $finishattempt = false,
+        $behaviour = 'deferredfeedback',
+            $includeqattachments = false, $extraoptions = []) {
+        global $DB;
 
         // Create a course.
         $course = $this->getDataGenerator()->create_course();
+
+        // Create a new quiz with attempts.
+        $data = ['course' => $course->id,
+                    'sumgrades' => 2,
+                    'preferredbehaviour' => $behaviour,
+                ];
+        $data = array_merge($data, $extraoptions);
+        $quiz = $this->getDataGenerator()->create_module('quiz', $data);
+
         // Get a hold of the quiz module contexts.
-        $quiz = $this->getDataGenerator()->create_module(
-            'quiz',
-            ['course' => $course->id, 'name' => 'Sample Quiz', 'sumgrades' => 1]
-        );
+        $cm = get_coursemodule_from_instance('quiz', $quiz->id);
+        $context = context_module::instance($cm->id);
 
-        return [$course, $quiz];
-    }
+        external_api::validate_context($context);
 
-    /**
-     * Create a quiz question and add it to the quiz.
-     *
-     * @param object $quiz The quiz object.
-     * @return object The created question object.
-     */
-    private function create_question($quiz): object {
+        // Create a couple of questions.
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
-        $category = $questiongenerator->create_question_category();
-        $question = $questiongenerator->create_question('essay', null, ['category' => $category->id]);
-        quiz_add_quiz_question($question->id, $quiz);
-        return $question;
-    }
 
-    /**
-     * Create a student and enroll them in the course.
-     *
-     * @param object $course The course object.
-     * @return object The created student object.
-     */
-    private function create_student_and_enroll($course): object {
+        $cat = $questiongenerator->create_question_category();
+
+        $question = $questiongenerator->create_question('essay', null, ['category' => $cat->id]);
+        quiz_add_quiz_question($question->id, $quiz);
+
+        $question = $questiongenerator->create_question('essay', null, ['category' => $cat->id]);
+        quiz_add_quiz_question($question->id, $quiz);
+
+        if ($includeqattachments) {
+            $question = $questiongenerator->create_question('essay', null, ['category' => $cat->id, 'attachments' => 1,
+                'attachmentsrequired' => 1]);
+            quiz_add_quiz_question($question->id, $quiz);
+        }
+
+        // Create a user and enroll them as student in the course.
+        $student = $this->getDataGenerator()->create_user();
+        $teacher = $this->getDataGenerator()->create_user();
+
+        $studentrole = $DB->get_record('role', ['shortname' => 'student']);
+        $teacherrole = $DB->get_record('role', ['shortname' => 'editingteacher']);
+
+        $this->getDataGenerator()->enrol_user($student->id, $course->id, $studentrole->id, 'manual');
+        $this->getDataGenerator()->enrol_user($teacher->id, $course->id, $teacherrole->id, 'manual');
+
         $student = $this->getDataGenerator()->create_user();
         $this->getDataGenerator()->enrol_user($student->id, $course->id, 'student');
-        return $student;
-    }
 
-    /**
-     * Create and start a quiz attempt for a given student.
-     *
-     * @param object $quiz The quiz object.
-     * @param object $student The student object.
-     * @return object The created quiz attempt.
-     */
-    private function create_and_start_quiz_attempt($quiz, $student): object {
-        $quizsettings = quiz_settings::create($quiz->id, $student->id);
-        $quba = question_engine::make_questions_usage_by_activity('mod_quiz', $quizsettings->get_context());
-        $quba->set_preferred_behaviour($quizsettings->get_quiz()->preferredbehaviour);
-        $attemptnumber = count(quiz_get_user_attempts($quizsettings->get_quizid(), $student->id)) + 1;
-        $attempt = quiz_create_attempt($quizsettings, $attemptnumber, false, time(), false, $student->id);
-        quiz_start_new_attempt($quizsettings, $quba, $attempt, 1, time());
-        quiz_attempt_save_started($quizsettings, $quba, $attempt);
+        // Create a quiz settings object for the student.
+        $quizobj = quiz_settings::create($quiz->id, $student->id);
 
-        return $attempt;
+        // Set grade to pass.
+        $item = \grade_item::fetch(['courseid' => $course->id, 'itemtype' => 'mod',
+                                        'itemmodule' => 'quiz', 'iteminstance' => $quiz->id, 'outcomeid' => null]);
+        $item->gradepass = 80;
+        $item->update();
+
+        if ($startattempt || $finishattempt) {
+            // Now, do one attempt.
+            $quba = \question_engine::make_questions_usage_by_activity('mod_quiz', $quizobj->get_context());
+            $quba->set_preferred_behaviour($quizobj->get_quiz()->preferredbehaviour);
+
+            $timenow = time();
+            $attemptnumber = count(quiz_get_user_attempts($quizobj->get_quizid(), $student->id)) + 1;
+            $attempt = quiz_create_attempt($quizobj, $attemptnumber, false, $timenow, false, $student->id);
+            quiz_start_new_attempt($quizobj, $quba, $attempt, 1, $timenow);
+            quiz_attempt_save_started($quizobj, $quba, $attempt);
+            $attemptobj = quiz_attempt::create($attempt->id);
+
+            if ($finishattempt) {
+                // Process some responses from the student.
+                $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
+                    $quba,
+                    [1 => 'Sample answer.'],
+                    true,
+                );
+                $attemptobj->process_submitted_actions(time(), false, $postdata);
+
+                // Finish the attempt.
+                $attemptobj->process_finish(time(), false);
+            }
+            return [$course, $quiz, $context, $quizobj, $attempt, $attemptobj, $quba];
+        } else {
+            return [$course, $quiz, $context, $quizobj];
+        }
+
     }
 }

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -1220,7 +1220,7 @@ final class api_test extends externallib_advanced_testcase {
 
         // Expect an exception when calling the API with an invalid attempt ID.
         $this->expectException(\moodle_exception::class);
-        $this->expectExceptionMessage('Invalid question id');
+        $this->expectExceptionMessage('No such attempt ID exists');
 
         // Call the method with an invalid attempt ID.
         api::set_question_attempt_mark(0, '1.0', 'Invalid attempt');

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -24,6 +24,7 @@
 
 namespace tool_ucsfsomapi;
 
+use assign;
 use context_module;
 use core_external\external_api;
 use core_external\external_multiple_structure;
@@ -844,9 +845,11 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEquals($timefinish1, $rhett[0]['timefinish']);
         $this->assertCount(2, $rhett[0]['questions']);
         $this->assertEquals($question1->id, $rhett[0]['questions'][0]['id']);
+        $this->assertEquals($attemptobj1->get_question_usage()->get_question_attempt(1)->get_database_id(), $rhett[0]['questions'][0]['attemptid']);
         $this->assertEquals(1.0, $rhett[0]['questions'][0]['mark']); // Correct answer.
         $this->assertEquals($answers1[1], $rhett[0]['questions'][0]['answer']);
         $this->assertEquals($question2->id, $rhett[0]['questions'][1]['id']);
+        $this->assertEquals($attemptobj1->get_question_usage()->get_question_attempt(2)->get_database_id(), $rhett[0]['questions'][1]['attemptid']);
         $this->assertEquals(0.0, $rhett[0]['questions'][1]['mark']); // Wrong answer.
         $this->assertEquals($answers1[2], $rhett[0]['questions'][1]['answer']);
 
@@ -857,9 +860,11 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEquals($timefinish2, $rhett[1]['timefinish']);
         $this->assertCount(2, $rhett[1]['questions']);
         $this->assertEquals($question1->id, $rhett[1]['questions'][0]['id']);
+        $this->assertEquals($attemptobj2->get_question_usage()->get_question_attempt(1)->get_database_id(), $rhett[1]['questions'][0]['attemptid']);
         $this->assertEquals(0.0, $rhett[1]['questions'][0]['mark']); // Wrong answer.
         $this->assertEquals($answers2[1], $rhett[1]['questions'][0]['answer']);
         $this->assertEquals($question2->id, $rhett[1]['questions'][1]['id']);
+        $this->assertEquals($attemptobj2->get_question_usage()->get_question_attempt(2)->get_database_id(), $rhett[1]['questions'][1]['attemptid']);
         $this->assertEquals(1.0, $rhett[1]['questions'][1]['mark']); // Correct answer.
         $this->assertEquals($answers2[2], $rhett[1]['questions'][1]['answer']);
     }
@@ -933,5 +938,442 @@ final class api_test extends externallib_advanced_testcase {
         $this->assertEquals($user1->idnumber, $rhett[0]['ucid']);
         $this->assertEquals($user2->id, $rhett[1]['id']);
         $this->assertEquals($user2->idnumber, $rhett[1]['ucid']);
+    }
+
+    /**
+     * Tests the input parameters definition for the "set_question_attempt_mark" endpoint.
+     */
+    public function test_set_question_attempt_mark_parameters(): void {
+        // Retrieve the parameter structure defined by the API.
+        $structure = api::set_question_attempt_mark_parameters();
+
+        // We expect three keys: attemptid, mark, and comment.
+        $this->assertCount(3, $structure->keys, 'Expected 3 keys in the parameters structure.');
+
+        // Validate "attemptid" key.
+        $attemptid = $structure->keys['attemptid'];
+        $this->assertInstanceOf(external_value::class, $attemptid);
+        $this->assertEquals(PARAM_INT, $attemptid->type, 'attemptid should be of type PARAM_INT.');
+        $this->assertEquals('The question attempt id to set mark.', $attemptid->desc);
+        // Value is required by default.
+        $this->assertEquals(VALUE_REQUIRED, $attemptid->required);
+
+        // Validate "mark" key.
+        $mark = $structure->keys['mark'];
+        $this->assertInstanceOf(external_value::class, $mark);
+        $this->assertEquals(PARAM_TEXT, $mark->type, 'mark should be of type PARAM_TEXT.');
+        $this->assertEquals('Mark for this question attempt.', $mark->desc);
+        $this->assertEquals(VALUE_REQUIRED, $mark->required);
+
+        // Validate "comment" key.
+        $comment = $structure->keys['comment'];
+        $this->assertInstanceOf(external_value::class, $comment);
+        $this->assertEquals(PARAM_RAW, $comment->type, 'comment should be of type PARAM_RAW.');
+        $this->assertEquals("Grader's comment for this question attempt (optional)", $comment->desc);
+        // Check that the "comment" is optional.
+        $this->assertEquals(VALUE_DEFAULT, $comment->required, 'comment should be an optional parameter.');
+    }
+
+    /**
+     * Tests the return value definition for the "set_question_attempt_mark" endpoint.
+     */
+    public function test_set_question_attempt_mark_returns(): void {
+        // Retrieve the return value structure defined by the API.
+        $result = api::set_question_attempt_mark_returns();
+
+        $this->assertEquals(PARAM_INT, $result->type, 'result should be of type PARAM_INT.');
+        $this->assertEquals('A value like 0 => OK, 1 => FAILED as defined in lib/grade/constants.php', $result->desc);
+        // Check that the "result" is required.
+        $this->assertEquals(VALUE_REQUIRED, $result->required, 'result should be a required parameter.');
+    }
+
+    /**
+     * Tests the "set_question_attempt_mark" endpoint.
+     *
+     * This test creates a course, a quiz module, and a dummy quiz attempt record.
+     * It then calls the API function with valid parameters and verifies that
+     * the expected result is returned.
+     */
+    public function test_set_question_attempt_mark(): void {
+        global $DB;
+
+        // Set up the test environment.
+        $this->setAdminUser();
+        [$course, $quiz] = $this->create_course_and_quiz();
+        $question = $this->create_question($quiz);
+        // $attemptid = $this->create_quiz_attempt($quiz, $student);
+
+        // Retrieve attempts for the quiz, should come up empty-handed.
+        $result = external_api::clean_returnvalue(
+            api::get_attempts_returns(),
+            api::get_attempts([$quiz->id])
+        );
+        $this->assertEmpty($result);
+
+        // Create a user and enroll them as student in the course.
+        $student = $this->create_student_and_enroll($course);
+
+        // Create a dummy quiz attempt record.
+        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
+
+        // Answer the question
+        // @see /mod/quiz/tests/external/external_test.php for reference.
+        $attemptobj = quiz_attempt::create($attempt->id);
+
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
+            $attemptobj->get_question_usage(),
+            [1 => 'True'],
+            true,
+        );
+        $attemptobj->process_submitted_actions(time(), false, $postdata);
+        // Finish the attempt.
+        $attemptobj->process_attempt(time(), true, false, 1);
+
+        // Get the question attempt ID.
+        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $attemptid = $qa->get_database_id();
+
+        // Call the API function with valid parameters.
+        $result = external_api::clean_returnvalue(
+            api::set_question_attempt_mark_returns(),
+            api::set_question_attempt_mark($attemptid, 1.0, 'Good job!')
+        );
+        // Assert the result.
+        $this->assertEquals(GRADE_UPDATE_OK, $result);
+
+        // Check the database to ensure the mark was set correctly.
+        $sql = 'SELECT qasd.*
+                FROM {question_attempt_steps} qas
+                JOIN {question_attempt_step_data} qasd ON qasd.attemptstepid = qas.id
+                WHERE qas.questionattemptid = :qaid AND qasd.name = :markingfield
+                ORDER BY qas.sequencenumber DESC LIMIT 1';
+        $params = ['qaid' => $attemptid, 'markingfield' => '-mark'];
+        $qasd = $DB->get_record_sql($sql, $params);
+
+        // Assert mark in the database.
+        $this->assertEquals(1.0, $qasd->value);
+
+        // Assert comment in the database.
+        $params = ['qaid' => $attemptid, 'markingfield' => '-comment'];
+        $qasd = $DB->get_record_sql($sql, $params);
+
+        $this->assertEquals('Good job!', $qasd->value);
+    }
+
+    /**
+     * Tests an invalid execution of the "set_question_attempt_mark" endpoint.
+     *
+     * This test creates a course, a quiz module, and a dummy quiz attempt record.
+     * It then calls the API function with an invalid attempt ID and verifies that
+     * the expected exception is thrown.
+     */
+    public function test_set_question_attempt_mark_invalid_attemptid() {
+        global $DB;
+
+        // Expect an exception when calling the API with an invalid attempt ID.
+        $this->expectException(\moodle_exception::class);
+        $this->expectExceptionMessage('Invalid question attempt ID.');
+
+        // Call the method with an invalid attempt ID.
+        api::set_question_attempt_mark(0, '1.0', 'Invalid attempt');
+        api::set_question_attempt_mark(99999, 1.0, 'Invalid attempt');
+    }
+
+    /**
+     * Test set_question_attempt_mark with invalid mark.
+     */
+    public function test_set_question_attempt_mark_invalid_mark() {
+        global $DB;
+
+        // Set up the test environment.
+        $this->setAdminUser();
+        [$course, $quiz] = $this->create_course_and_quiz();
+        $question = $this->create_question($quiz);
+
+        // Retrieve attempts for the quiz, should come up empty-handed.
+        $result = external_api::clean_returnvalue(
+            api::get_attempts_returns(),
+            api::get_attempts([$quiz->id])
+        );
+        $this->assertEmpty($result);
+
+        // Create a user and enroll them as student in the course.
+        $student = $this->create_student_and_enroll($course);
+
+        // Create a dummy quiz attempt record.
+        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
+
+        // Answer the question
+        // @see /mod/quiz/tests/external/external_test.php for reference.
+        $attemptobj = quiz_attempt::create($attempt->id);
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+
+        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
+            $attemptobj->get_question_usage(),
+            [1 => 'True'],
+            true,
+        );
+        $attemptobj->process_submitted_actions(time(), false, $postdata);
+        // Finish the attempt.
+        $attemptobj->process_attempt(time(), true, false, 1);
+
+        // Get the question attempt ID.
+        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $attemptid = $qa->get_database_id();
+
+        // Call the API function with valid parameters.
+        $result = external_api::clean_returnvalue(
+            api::set_question_attempt_mark_returns(),
+            api::set_question_attempt_mark($attemptid, 'invalid_mark', 'Invalid mark')
+        );
+
+        // Assert the result.
+        $this->assertEquals(GRADE_UPDATE_FAILED, $result);
+    }
+
+    /**
+     * Test set_question_attempt_mark with invalid comment.
+     */
+    public function test_set_question_attempt_mark_invalid_comment() {
+        global $DB;
+
+        // Set up the test environment.
+        $this->setAdminUser();
+        [$course, $quiz] = $this->create_course_and_quiz();
+        $question = $this->create_question($quiz);
+
+
+        // Retrieve attempts for the quiz, should come up empty-handed.
+        $result = external_api::clean_returnvalue(
+            api::get_attempts_returns(),
+            api::get_attempts([$quiz->id])
+        );
+        $this->assertEmpty($result);
+
+        // Create a user and enroll them as student in the course.
+        $student = $this->create_student_and_enroll($course);
+
+        // Create a dummy quiz attempt record.
+        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
+
+        // Answer the question
+        // @see /mod/quiz/tests/external/external_test.php for reference.
+        $attemptobj = quiz_attempt::create($attempt->id);
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
+            $attemptobj->get_question_usage(),
+            [1 => 'True'],
+            true,
+        );
+        $attemptobj->process_submitted_actions(time(), false, $postdata);
+        // Finish the attempt.
+        $attemptobj->process_attempt(time(), true, false, 1);
+
+        // Get the question attempt ID.
+        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $attemptid = $qa->get_database_id();
+
+        // Call the method with an invalid comment.
+        $this->expectException(\moodle_exception::class);
+        $this->expectExceptionMessage('Invalid parameter value detected (Invalid external api parameter: the value is " Invalid Comment", the server was expecting "raw" type): Invalid external api parameter: the value is " Invalid Comment", the server was expecting "raw" type');
+
+        // Call the API function with valid parameters.
+        $result = external_api::clean_returnvalue(
+            api::set_question_attempt_mark_returns(),
+            api::set_question_attempt_mark($attemptid, '1.0', "\0Invalid\0Comment")
+            // api::set_question_attempt_mark($attemptid, '1.0', null)
+            // api::set_question_attempt_mark($attemptid, '1.0', str_repeat('a', 10001))
+        );
+    }
+
+    /**
+     * Test set_question_attempt_mark with unfinished attempt.
+     */
+    public function test_set_question_attempt_mark_unfinished_attempt() {
+        global $DB;
+
+        $this->resetAfterTest(true);
+
+        // Create a mock quiz attempt and question attempt.
+        [$course, $quiz] = $this->create_course_and_quiz();
+        $question = $this->create_question($quiz);
+
+        // Create a user and enroll them as student in the course.
+        $student = $this->create_student_and_enroll($course);
+
+        // Create a dummy quiz attempt record.
+        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
+
+        // Answer the question
+        // @see /mod/quiz/tests/external/external_test.php for reference.
+        $attemptobj = quiz_attempt::create($attempt->id);
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+
+        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
+            $attemptobj->get_question_usage(),
+            [1 => 'True'],
+            true,
+        );
+        $attemptobj->process_submitted_actions(time(), false, $postdata);
+
+        // Get the question attempt ID.
+        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $attemptid = $qa->get_database_id();
+
+        $this->expectException(\moodle_exception::class);
+        $this->expectExceptionMessage('Attempt has not closed yet');
+
+        // Call the method with an unfinished attempt.
+        $result = external_api::clean_returnvalue(
+            api::set_question_attempt_mark_returns(),
+            api::set_question_attempt_mark($attemptid, 1.0, 'Good job!')
+        );
+    }
+
+    /**
+     * Test set_question_attempt_mark with missing 'mod/quiz:grade' capability.
+     */
+    public function test_set_question_attempt_mark_missing_quiz_grade_capability() {
+        global $DB;
+
+        $this->resetAfterTest(true);
+
+        // Set up the test environment.
+        $this->setAdminUser();
+
+        // Create a mock quiz attempt and question attempt.
+        [$course, $quiz] = $this->create_course_and_quiz();
+        $question = $this->create_question($quiz);
+
+
+        // Retrieve attempts for the quiz, should come up empty-handed.
+        $result = external_api::clean_returnvalue(
+            api::get_attempts_returns(),
+            api::get_attempts([$quiz->id])
+        );
+        $this->assertEmpty($result);
+
+        // Create a user and enroll them as student in the course.
+        $student = $this->create_student_and_enroll($course);
+
+        // Create a dummy quiz attempt record.
+        $attempt = $this->create_and_start_quiz_attempt($quiz, $student);
+
+        // Answer the question
+        // @see /mod/quiz/tests/external/external_test.php for reference.
+        $attemptobj = quiz_attempt::create($attempt->id);
+
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $postdata = $questiongenerator->get_simulated_post_data_for_questions_in_usage(
+            $attemptobj->get_question_usage(),
+            [1 => 'True'],
+            true,
+        );
+        $attemptobj->process_submitted_actions(time(), false, $postdata);
+
+        // Finish the attempt.
+        $attemptobj->process_attempt(time(), true, false, 1);
+
+        // Get the question attempt ID.
+        $qa = $attemptobj->get_question_usage()->get_question_attempt(1);
+        $attemptid = $qa->get_database_id();
+
+        // Create a user and attempt to set a mark without proper permissions.
+        $grader = $this->getDataGenerator()->create_user();
+        $graderrole = $DB->get_record('role', ['shortname' => 'teacher']);
+        $this->getDataGenerator()->enrol_user($grader->id, $course->id, $graderrole->id);
+
+        $this->setUser($grader);
+
+        // Obtain the course module ID.
+        $cm = get_coursemodule_from_instance('quiz', $quiz->id, $course->id);
+        $cmid = $cm->id;
+        // Set the context for the quiz module.
+        $context = context_module::instance($cmid);
+
+        // Check that the user has the "mod/quiz:grade" capability.
+        $this->assertTrue(has_capability('mod/quiz:grade', $context, $grader->id));
+
+        // Remove grading capability.
+        assign_capability('mod/quiz:grade', CAP_PROHIBIT, $graderrole->id, $context->id);
+
+        // Check that the user no longer has the "mod/quiz:grade" capability.
+        $this->assertFalse(has_capability('mod/quiz:grade', $context, $grader->id));
+
+        // Expect an exception when calling the API with missing permissions.
+        $this->expectException(\moodle_exception::class);
+        $this->expectExceptionMessage('Sorry, but you do not currently have permissions to do that (Grade quizzes manually).');
+
+        // Call the method without proper permissions.
+        $result = external_api::clean_returnvalue(
+            api::set_question_attempt_mark_returns(),
+            api::set_question_attempt_mark($attemptid, '1.0', 'No permissions')
+        );
+    }
+
+    /**
+     * Helper methods for common setup tasks.
+     */
+
+    /**
+     * Create a course and a quiz module.
+     *
+     * @return array The created course and quiz objects.
+     */
+    private function create_course_and_quiz(): array {
+
+        // Create a course.
+        $course = $this->getDataGenerator()->create_course();
+        // Get a hold of the quiz module contexts.
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id, 'name' => 'Sample Quiz', 'sumgrades' => 1]);
+
+        return [$course, $quiz];
+    }
+
+    /**
+     * Create a quiz question and add it to the quiz.
+     *
+     * @param object $quiz The quiz object.
+     * @return object The created question object.
+     */
+    private function create_question($quiz): object {
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $category = $questiongenerator->create_question_category();
+        $question = $questiongenerator->create_question('truefalse', null, ['category' => $category->id]);
+        quiz_add_quiz_question($question->id, $quiz);
+        return $question;
+    }
+
+    /**
+     * Create a student and enroll them in the course.
+     *
+     * @param object $course The course object.
+     * @return object The created student object.
+     */
+    private function create_student_and_enroll($course): object {
+        $student = $this->getDataGenerator()->create_user();
+        //$studentrole = $DB->get_record('role', ['shortname' => 'student']);
+        $this->getDataGenerator()->enrol_user($student->id, $course->id, 'student');
+        return $student;
+    }
+
+    /**
+     * Create and start a quiz attempt for a given student.
+     *
+     * @param object $quiz The quiz object.
+     * @param object $student The student object.
+     * @return object The created quiz attempt.
+     */
+    private function create_and_start_quiz_attempt($quiz, $student): object {
+        $quizsettings = quiz_settings::create($quiz->id, $student->id);
+        $quba = question_engine::make_questions_usage_by_activity('mod_quiz', $quizsettings->get_context());
+        $quba->set_preferred_behaviour($quizsettings->get_quiz()->preferredbehaviour);
+        $attemptnumber = count(quiz_get_user_attempts($quizsettings->get_quizid(), $student->id)) + 1;
+        $attempt = quiz_create_attempt($quizsettings, $attemptnumber, false, time(), false, $student->id);
+        quiz_start_new_attempt($quizsettings, $quba, $attempt, 1, time());
+        quiz_attempt_save_started($quizsettings, $quba, $attempt);
+
+        return $attempt;
     }
 }

--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -1061,18 +1061,28 @@ final class api_test extends externallib_advanced_testcase {
         $sink->close();
 
         // Check that the event count is correct.
-        $this->assertCount(1, $events);
+        $this->assertCount(2, $events);
+
+        // Validate the call_to_set_question_attempt_mark_api event.
+        $event = $events[0];
+        $this->assertInstanceOf('\tool_ucsfsomapi\event\set_question_attempt_mark_called', $event);
+        $this->assertEquals('question', $event->objecttable);
+        $this->assertEquals($attemptid, $event->objectid);
+        $this->assertEquals(\context_system::instance(), $event->get_context());
+        $this->assertEquals('1', $event->other['mark']);
+        $this->assertEquals('Good job!', $event->other['comment']);
+        $this->assertEventContextNotUsed($event);
 
         // Validate the question_manually_graded event.
-        $event = $events[0];
-        $this->assertInstanceOf('\mod_quiz\event\question_manually_graded', $event);
+        $event = $events[1];
+        $this->assertInstanceOf('\tool_ucsfsomapi\event\question_attempt_marked', $event);
         $this->assertEquals('question', $event->objecttable);
         $this->assertEquals($qa->get_question_id(), $event->objectid);
         $this->assertEquals($course->id, $event->courseid);
         $this->assertEquals($attemptobj->get_context(), $event->get_context());
-        $this->assertEquals($attempt->quiz, $event->other['quizid']); // Should be the user, but PHP Unit complains...
-        $this->assertEquals($attempt->id, $event->other['attemptid']); // Should be the user, but PHP Unit complains...
-        $this->assertEquals($qa->get_slot(), $event->other['slot']); // Should be the user, but PHP Unit complains...
+        $this->assertEquals($attempt->quiz, $event->other['quizid']);
+        $this->assertEquals($attempt->id, $event->other['attemptid']);
+        $this->assertEquals($qa->get_slot(), $event->other['slot']);
         $this->assertEventContextNotUsed($event);
 
         // Check the database to ensure the mark was set correctly.

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'tool_ucsfsomapi';
-$plugin->version   = 2024092701;
+$plugin->version   = 2024092702;
 $plugin->requires  = 2024041600;
 $plugin->supported = [404, 404];
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
- **First implementation of the set_question_attempt_mark API with unit tests.**
- **Fix Code and PHPDoc checkers errors and warnings.**
- #1 in README.md as a simple and quick solution since we do not have a large number of APIs at this moment. We should probably move this out of the README.md if it grows out of control in the future.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210368355388609